### PR TITLE
Simplify DataPusher build scripts, bump to latest version

### DIFF
--- a/datapusher/Dockerfile
+++ b/datapusher/Dockerfile
@@ -1,8 +1,7 @@
 FROM alpine:3.13
 
-ARG DATAPUSHER_VERSION
+ARG DATAPUSHER_VERSION=master
 ENV APP_DIR=/srv/app
-ENV GIT_BRANCH 0.0.18
 ENV GIT_URL https://github.com/ckan/datapusher.git
 ENV JOB_CONFIG ${APP_DIR}/datapusher_settings.py
 
@@ -32,7 +31,7 @@ RUN apk add --no-cache \
     cargo
 
 RUN mkdir ${APP_DIR}/src && cd ${APP_DIR}/src && \
-    git clone -b ${GIT_BRANCH} --depth=1 --single-branch ${GIT_URL} && \
+    git clone -b ${DATAPUSHER_VERSION} --depth=1 --single-branch ${GIT_URL} && \
     cd datapusher && \
     python3 setup.py install
 

--- a/datapusher/Makefile
+++ b/datapusher/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all help build build-all push
 SHELL := /bin/bash
-DATAPUSHER_VERSION=0.0.18
+DATAPUSHER_VERSION=0.0.19
 TAG_NAME="ckan/ckan-base-datapusher:$(DATAPUSHER_VERSION)"
 
 all: help

--- a/datapusher/Makefile
+++ b/datapusher/Makefile
@@ -7,12 +7,9 @@ all: help
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-build:	## Build a DataPusher 0.0.18 image , `make build`
-ifeq ($(DATAPUSHER_VERSION),$(filter $(DATAPUSHER_VERSION),0.0.18))
-	docker build -t $(TAG_NAME) .
-endif
+build: ## Build a DataPusher image
+	echo "Building DataPusher image for version $(DATAPUSHER_VERSION)"
+	docker build -t $(TAG_NAME) --build-arg DATAPUSHER_VERSION=$(DATAPUSHER_VERSION) .
 
-push: ## Push a DataPusher 0.0.18 image to the DockerHub registry, `make push`
-ifeq ($(DATAPUSHER_VERSION),$(filter $(DATAPUSHER_VERSION),0.0.18))
+push: ## Push a DataPusher image to the Docker Hub registry
 	docker push $(TAG_NAME)
-endif


### PR DESCRIPTION
It's best to have the version to build defined in one single place, in this case the Makefile rather than across different files.

When there's a new version we can update the Makefile and if some builds the image without using `make build` they'll always get the `master` branch.

Also bumps the build version to 0.0.19