### PR TITLE
Remove requirement-setuptools from the 2.10 image

### DIFF
--- a/ckan-2.10/base/Dockerfile
+++ b/ckan-2.10/base/Dockerfile
@@ -69,7 +69,6 @@ COPY setup/supervisord.conf /etc
 RUN pip3 install -e git+${GIT_URL}@${GIT_BRANCH}#egg=ckan && \
     cd ${SRC_DIR}/ckan && \
     cp who.ini ${APP_DIR} && \
-    pip3 install -r requirement-setuptools.txt && \
     pip3 install --no-binary markdown -r requirements.txt && \
     # Install CKAN envvars to support loading config from environment variables
     pip3 install -e git+https://github.com/okfn/ckanext-envvars.git#egg=ckanext-envvars && \


### PR DESCRIPTION
Taken the `pip3 install -r requirement-setuptools.txt && \` line out of the 2.10 Dockerfile