### PR TITLE
Use new rDockerHub repo for dev images

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ The following CKAN versions are available in base or dev forms. They are disting
 | 2.9.8 | base image | `ckan/ckan-base:ckan-2.9.8` |  |
 | 2.9.8 | dev image | `ckan/ckan-base:ckan-2.9.8-dev` |  |
 | 2.9.9 | base image | `ckan/ckan-base:ckan-2.9.9` |  |
-| 2.9.9 | dev image | `ckan/ckan-base:ckan-2.9.9-dev` |  |
+| 2.9.9 | dev image | `ckan/ckan-dev:ckan-2.9.9` |  |
 | 2.10.0 | base image | `ckan/ckan-base:ckan-2.10.0` |  |
 | 2.10.0 | dev image | `ckan/ckan-base:ckan-2.10.0-dev` |  |
 | 2.10.1 | base image | `ckan/ckan-base:ckan-2.10.1` |  |
-| 2.10.1 | dev image | `ckan/ckan-base:ckan-2.10.1-dev` |  |
+| 2.10.1 | dev image | `ckan/ckan-dev:ckan-2.10.1` |  |
 
 
 ### Building and Pushing the images

--- a/ckan-2.10/dev/Makefile
+++ b/ckan-2.10/dev/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all help build build-all push
 SHELL := /bin/bash
-CKAN_VERSION=2.10.1-dev
-TAG_NAME="ckan/ckan-base:$(CKAN_VERSION)"
+CKAN_VERSION=2.10.1
+TAG_NAME="ckan/ckan-dev:$(CKAN_VERSION)"
 
 all: help
 help:

--- a/ckan-2.9/dev/Makefile
+++ b/ckan-2.9/dev/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all help build build-all push
 SHELL := /bin/bash
-CKAN_VERSION=2.9.9-dev
-TAG_NAME="ckan/ckan-base:$(CKAN_VERSION)"
+CKAN_VERSION=2.9.9
+TAG_NAME="ckan/ckan-dev:$(CKAN_VERSION)"
 
 all: help
 help:


### PR DESCRIPTION
The ckan/ckan-dev repo is the new DockerHub home for CKAN dev images