### PR TITLE
Update alpine in 2.9 image to match 2.10 image

### DIFF
--- a/ckan-2.9/base/Dockerfile
+++ b/ckan-2.9/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.17
 ARG CKAN_VERSION=ckan-2.9.9
 
 # Internals, you probably don't need to change these


### PR DESCRIPTION
2.10 image uses alpine 3.17 https://github.com/ckan/ckan-docker-base/blob/7cdec3f452fff1e66bac1e416585125151a55258/ckan-2.10/base/Dockerfile#L1, this updates to 2.9 image to that as well unless there is specific reason not to have it.