### PR TITLE
Decouple datapusher from init scripts

### DIFF
--- a/ckan-2.10/base/Dockerfile
+++ b/ckan-2.10/base/Dockerfile
@@ -12,7 +12,7 @@ ENV GIT_URL=https://github.com/ckan/ckan.git
 ENV GIT_BRANCH=${CKAN_VERSION}
 # Customize these on the .env file if needed
 ENV CKAN_SITE_URL=http://localhost:5000
-ENV CKAN__PLUGINS image_view text_view recline_view datastore datapusher envvars
+ENV CKAN__PLUGINS image_view text_view recline_view datastore envvars
 
 # UWSGI options
 ENV UWSGI_HARAKIRI=50

--- a/ckan-2.10/dev/setup/start_ckan_development.sh
+++ b/ckan-2.10/dev/setup/start_ckan_development.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+if [[ $CKAN__PLUGINS == *"datapusher"* ]]; then
+    # Add ckan.datapusher.api_token to the CKAN config file (updated with corrected value later)
+    echo "Setting a temporary value for ckan.datapusher.api_token"
+    ckan config-tool $CKAN_INI ckan.datapusher.api_token=xxx
+fi
+
 # Install any local extensions in the src_extensions volume
 echo "Looking for local extensions to install..."
 echo "Extension dir contents:"
@@ -45,9 +51,6 @@ done
 echo "Enabling debug mode"
 ckan config-tool $CKAN_INI -s DEFAULT "debug = true"
 
-# Add ckan.datapusher.api_token to the CKAN config file (updated with corrected value later)
-ckan config-tool $CKAN_INI ckan.datapusher.api_token=xxx
-
 # Set up the Secret key used by Beaker and Flask
 # This can be overriden using a CKAN___BEAKER__SESSION__SECRET env var
 if grep -E "beaker.session.secret ?= ?$" ckan.ini
@@ -75,9 +78,6 @@ ckan config-tool $SRC_DIR/ckan/test-core.ini \
 
 # Run the prerun script to init CKAN and create the default admin user
 python3 prerun.py
-
-echo "Set up ckan.datapusher.api_token in the CKAN config file"
-ckan config-tool $CKAN_INI "ckan.datapusher.api_token=$(ckan -c $CKAN_INI user token add ckan_admin datapusher | tail -n 1 | tr -d '\t')"
 
 # Run any startup scripts provided by images extending this one
 if [[ -d "/docker-entrypoint.d" ]]

--- a/ckan-2.9/base/Dockerfile
+++ b/ckan-2.9/base/Dockerfile
@@ -12,7 +12,7 @@ ENV GIT_URL=https://github.com/ckan/ckan.git
 ENV GIT_BRANCH=${CKAN_VERSION}
 # Customize these on the .env file if needed
 ENV CKAN_SITE_URL=http://localhost:5000
-ENV CKAN__PLUGINS image_view text_view recline_view datastore datapusher envvars
+ENV CKAN__PLUGINS image_view text_view recline_view datastore envvars
 
 # UWSGI options
 ENV UWSGI_HARAKIRI=50


### PR DESCRIPTION
As discussed in ckan/ckan-docker#95

Remove datapusher from default plugin list env var and remove setup commands from the entrypoint scripts
(start_ckan.sh/start_ckan_development.sh)

Sadly we still need the one to add a temporary value on the api token config option, otherwise all `ckan` commands will fail, but at least we only run it if datapusher is listed in CKAN__PLUGINS