### PR TITLE
Update Makefiles with alt tags, push to repo

### DIFF
--- a/ckan-2.10/base/Makefile
+++ b/ckan-2.10/base/Makefile
@@ -11,13 +11,11 @@ help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 build:	## Build a CKAN 2.x.x image , `make build`
-	echo "Building $(TAG_NAME) image"
-	docker build --build-arg="CKAN_VERSION=ckan-$(CKAN_VERSION)" -t $(TAG_NAME) .
-	echo "Tagging $(TAG_NAME) image as $(ALT_TAG_NAME)"
-	docker build --build-arg="CKAN_VERSION=ckan-$(CKAN_VERSION)" -t $(ALT_TAG_NAME) .
+	echo "Building $(TAG_NAME) and $(ALT_TAG_NAME) images"
+	docker build --build-arg="CKAN_VERSION=ckan-$(CKAN_VERSION)" -t $(TAG_NAME) -t $(ALT_TAG_NAME) .
 
 push: ## Push a CKAN 2.x.x image to the DockerHub registry, `make push`
 	echo "Pushing $(TAG_NAME) image"
 	docker push $(TAG_NAME)
-	echo "Pushing $(ALT_TAG_NAME) image"
+	#echo "Pushing $(ALT_TAG_NAME) image"
 	docker push $(ALT_TAG_NAME)

--- a/ckan-2.10/base/Makefile
+++ b/ckan-2.10/base/Makefile
@@ -1,14 +1,23 @@
 .PHONY: all help build build-all push
 SHELL := /bin/bash
 CKAN_VERSION=2.10.1
+CKAN_VERSION_MAJOR=$(shell echo $(CKAN_VERSION) | cut -d'.' -f1)
+CKAN_VERSION_MINOR=$(shell echo $(CKAN_VERSION) | cut -d'.' -f2)
 TAG_NAME="ckan/ckan-base:$(CKAN_VERSION)"
+ALT_TAG_NAME="ckan/ckan-base:$(CKAN_VERSION_MAJOR).$(CKAN_VERSION_MINOR)"
 
 all: help
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 build:	## Build a CKAN 2.x.x image , `make build`
+	echo "Building $(TAG_NAME) image"
 	docker build --build-arg="CKAN_VERSION=ckan-$(CKAN_VERSION)" -t $(TAG_NAME) .
+	echo "Tagging $(TAG_NAME) image as $(ALT_TAG_NAME)"
+	docker build --build-arg="CKAN_VERSION=ckan-$(CKAN_VERSION)" -t $(ALT_TAG_NAME) .
 
 push: ## Push a CKAN 2.x.x image to the DockerHub registry, `make push`
+	echo "Pushing $(TAG_NAME) image"
 	docker push $(TAG_NAME)
+	echo "Pushing $(ALT_TAG_NAME) image"
+	docker push $(ALT_TAG_NAME)

--- a/ckan-2.10/dev/Makefile
+++ b/ckan-2.10/dev/Makefile
@@ -1,14 +1,23 @@
 .PHONY: all help build build-all push
 SHELL := /bin/bash
 CKAN_VERSION=2.10.1
+CKAN_VERSION_MAJOR=$(shell echo $(CKAN_VERSION) | cut -d'.' -f1)
+CKAN_VERSION_MINOR=$(shell echo $(CKAN_VERSION) | cut -d'.' -f2)
 TAG_NAME="ckan/ckan-dev:$(CKAN_VERSION)"
+ALT_TAG_NAME="ckan/ckan-dev:$(CKAN_VERSION_MAJOR).$(CKAN_VERSION_MINOR)"
 
 all: help
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 build:	## Build a CKAN 2.x-dev image , `make build`
+	echo "Building $(TAG_NAME) image"
 	docker build --build-arg="CKAN_VERSION=ckan-$(CKAN_VERSION)" -t $(TAG_NAME) .
+	echo "Tagging $(TAG_NAME) image as $(ALT_TAG_NAME)"
+	docker build --build-arg="CKAN_VERSION=ckan-$(CKAN_VERSION)" -t $(ALT_TAG_NAME) .
 
 push: ## Push a CKAN 2.x-dev image to the DockerHub registry, `make push`
+	echo "Pushing $(TAG_NAME) image"
 	docker push $(TAG_NAME)
+	echo "Pushing $(ALT_TAG_NAME) image"
+	docker push $(ALT_TAG_NAME)

--- a/ckan-2.10/dev/Makefile
+++ b/ckan-2.10/dev/Makefile
@@ -11,10 +11,8 @@ help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 build:	## Build a CKAN 2.x-dev image , `make build`
-	echo "Building $(TAG_NAME) image"
-	docker build --build-arg="CKAN_VERSION=ckan-$(CKAN_VERSION)" -t $(TAG_NAME) .
-	echo "Tagging $(TAG_NAME) image as $(ALT_TAG_NAME)"
-	docker build --build-arg="CKAN_VERSION=ckan-$(CKAN_VERSION)" -t $(ALT_TAG_NAME) .
+	echo "Building $(TAG_NAME) and $(ALT_TAG_NAME) images"
+	docker build --build-arg="CKAN_VERSION=ckan-$(CKAN_VERSION)" -t $(TAG_NAME) -t $(ALT_TAG_NAME) .
 
 push: ## Push a CKAN 2.x-dev image to the DockerHub registry, `make push`
 	echo "Pushing $(TAG_NAME) image"

--- a/ckan-2.9/base/Makefile
+++ b/ckan-2.9/base/Makefile
@@ -2,8 +2,10 @@
 SHELL := /bin/bash
 
 CKAN_VERSION=2.9.9
-
+CKAN_VERSION_MAJOR=$(shell echo $(CKAN_VERSION) | cut -d'.' -f1)
+CKAN_VERSION_MINOR=$(shell echo $(CKAN_VERSION) | cut -d'.' -f2)
 TAG_NAME="ckan/ckan-base:$(CKAN_VERSION)"
+ALT_TAG_NAME="ckan/ckan-base:$(CKAN_VERSION_MAJOR).$(CKAN_VERSION_MINOR)"
 
 all: help
 help:
@@ -11,7 +13,13 @@ help:
 
 
 build:	## Build a CKAN 2.x.x image , `make build`
+	echo "Building $(TAG_NAME) image"
 	docker build --build-arg="CKAN_VERSION=ckan-$(CKAN_VERSION)" -t $(TAG_NAME) .
+	echo "Tagging $(TAG_NAME) image as $(ALT_TAG_NAME)"
+	docker build --build-arg="CKAN_VERSION=ckan-$(CKAN_VERSION)" -t $(ALT_TAG_NAME) .
 
 push: ## Push a CKAN 2.x.x image to the DockerHub registry, `make push`
+	echo "Pushing $(TAG_NAME) image"
 	docker push $(TAG_NAME)
+	echo "Pushing $(ALT_TAG_NAME) image"
+	docker push $(ALT_TAG_NAME)

--- a/ckan-2.9/base/Makefile
+++ b/ckan-2.9/base/Makefile
@@ -13,10 +13,8 @@ help:
 
 
 build:	## Build a CKAN 2.x.x image , `make build`
-	echo "Building $(TAG_NAME) image"
-	docker build --build-arg="CKAN_VERSION=ckan-$(CKAN_VERSION)" -t $(TAG_NAME) .
-	echo "Tagging $(TAG_NAME) image as $(ALT_TAG_NAME)"
-	docker build --build-arg="CKAN_VERSION=ckan-$(CKAN_VERSION)" -t $(ALT_TAG_NAME) .
+	echo "Building $(TAG_NAME) and $(ALT_TAG_NAME) images"
+	docker build --build-arg="CKAN_VERSION=ckan-$(CKAN_VERSION)" -t $(TAG_NAME) -t $(ALT_TAG_NAME) .
 
 push: ## Push a CKAN 2.x.x image to the DockerHub registry, `make push`
 	echo "Pushing $(TAG_NAME) image"

--- a/ckan-2.9/dev/Makefile
+++ b/ckan-2.9/dev/Makefile
@@ -11,13 +11,13 @@ help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 build:	## Build a CKAN 2.x-dev image , `make build`
-	echo "Building $(TAG_NAME) image"
-	docker build --build-arg="CKAN_VERSION=ckan-$(CKAN_VERSION)" -t $(TAG_NAME) .
-	echo "Tagging $(TAG_NAME) image as $(ALT_TAG_NAME)"
-	docker build --build-arg="CKAN_VERSION=ckan-$(CKAN_VERSION)" -t $(ALT_TAG_NAME) .
+	echo "Building $(TAG_NAME) and $(ALT_TAG_NAME) images"
+	docker build --build-arg="CKAN_VERSION=ckan-$(CKAN_VERSION)" -t $(TAG_NAME) -t $(ALT_TAG_NAME) .
 
 push: ## Push a CKAN 2.x-dev image to the DockerHub registry, `make push`
 	echo "Pushing $(TAG_NAME) image"
 	docker push $(TAG_NAME)
 	echo "Pushing $(ALT_TAG_NAME) image"
 	docker push $(ALT_TAG_NAME)
+
+

--- a/ckan-2.9/dev/Makefile
+++ b/ckan-2.9/dev/Makefile
@@ -1,14 +1,23 @@
 .PHONY: all help build build-all push
 SHELL := /bin/bash
 CKAN_VERSION=2.9.9
+CKAN_VERSION_MAJOR=$(shell echo $(CKAN_VERSION) | cut -d'.' -f1)
+CKAN_VERSION_MINOR=$(shell echo $(CKAN_VERSION) | cut -d'.' -f2)
 TAG_NAME="ckan/ckan-dev:$(CKAN_VERSION)"
+ALT_TAG_NAME="ckan/ckan-dev:$(CKAN_VERSION_MAJOR).$(CKAN_VERSION_MINOR)"
 
 all: help
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 build:	## Build a CKAN 2.x-dev image , `make build`
+	echo "Building $(TAG_NAME) image"
 	docker build --build-arg="CKAN_VERSION=ckan-$(CKAN_VERSION)" -t $(TAG_NAME) .
+	echo "Tagging $(TAG_NAME) image as $(ALT_TAG_NAME)"
+	docker build --build-arg="CKAN_VERSION=ckan-$(CKAN_VERSION)" -t $(ALT_TAG_NAME) .
 
 push: ## Push a CKAN 2.x-dev image to the DockerHub registry, `make push`
+	echo "Pushing $(TAG_NAME) image"
 	docker push $(TAG_NAME)
+	echo "Pushing $(ALT_TAG_NAME) image"
+	docker push $(ALT_TAG_NAME)


### PR DESCRIPTION
Fixes https://github.com/ckan/ckan-docker-base/issues/36

There is a requirement to use alternative tags for the CKAN images ie: `major. minor` version (eg: `2.10`) for the ckan/ckan-base and ckan/ckan-dev images