### PR TITLE
Build ckan 2.10.3 and 2.9.10 images

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,19 +23,19 @@ Older CKAN versions might be available as [image tags](https://hub.docker.com/r/
 The images can be built locally and tagged appropriately so they can then be pushed into the CKAN DockerHub repo
 assuming you have the correct permission to do so
 
-For CKAN 2.9.10 base images, go to the `ckan-2.9/base` directory and use the Makefile included:
+For CKAN 2.9.* base images, go to the `ckan-2.9/base` directory and use the Makefile included:
 
     cd ckan-2.9/base
     make build (can then use locally)
     make push (if you have enough credentials)
 
-For CKAN 2.9.10 dev images, go to the `ckan-2.9/dev` directory and use the Makefile included:
+For CKAN 2.9.* dev images, go to the `ckan-2.9/dev` directory and use the Makefile included:
 
     cd ckan-2.9/dev
     make build (can then use locally)
     make push (if you have enough credentials)
 
-Same with the CKAN 2.10.3 base and dev images 
+Same with the CKAN 2.10.* base and dev images 
 
     cd ckan-2.10/base
     make build

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ The following CKAN versions are available in base or dev forms. They are disting
 
 | CKAN Version | Type | Docker tag | Notes |
 | --- | --- | --- | --- |
-| 2.9.9 | base image | `ckan/ckan-base:2.9.9` |  |
-| 2.9.9 | dev image | `ckan/ckan-dev:2.9.9` |  |
-| 2.10.1 | base image | `ckan/ckan-base:2.10.1` |  |
-| 2.10.1 | dev image | `ckan/ckan-dev:2.10.1` |  |
+| 2.9.10 | base image | `ckan/ckan-base:2.9.10` |  |
+| 2.9.10 | dev image | `ckan/ckan-dev:2.9.10` |  |
+| 2.10.3 | base image | `ckan/ckan-base:2.10.3` |  |
+| 2.10.3 | dev image | `ckan/ckan-dev:2.10.3` |  |
 
 Older CKAN versions might be available as [image tags](https://hub.docker.com/r/ckan/ckan-base/tags) but note that these are not supported as per [CKAN's release policy](https://docs.ckan.org/en/latest/maintaining/releases.html#supported-versions).
 

--- a/README.md
+++ b/README.md
@@ -23,19 +23,19 @@ Older CKAN versions might be available as [image tags](https://hub.docker.com/r/
 The images can be built locally and tagged appropriately so they can then be pushed into the CKAN DockerHub repo
 assuming you have the correct permission to do so
 
-For CKAN 2.9.9 base images, go to the `ckan-2.9/base` directory and use the Makefile included:
+For CKAN 2.9.10 base images, go to the `ckan-2.9/base` directory and use the Makefile included:
 
     cd ckan-2.9/base
     make build (can then use locally)
     make push (if you have enough credentials)
 
-For CKAN 2.9.9 dev images, go to the `ckan-2.9/dev` directory and use the Makefile included:
+For CKAN 2.9.10 dev images, go to the `ckan-2.9/dev` directory and use the Makefile included:
 
     cd ckan-2.9/dev
     make build (can then use locally)
     make push (if you have enough credentials)
 
-Same with the CKAN 2.10.1 base and dev images 
+Same with the CKAN 2.10.3 base and dev images 
 
     cd ckan-2.10/base
     make build

--- a/ckan-2.10/base/Dockerfile
+++ b/ckan-2.10/base/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.17
-ARG CKAN_VERSION=ckan-2.10.1
+ARG CKAN_VERSION=ckan-2.10.3
 
 # Internals, you probably don't need to change these
 ENV TZ=UTC
@@ -77,9 +77,6 @@ COPY setup/supervisord.conf /etc
 RUN pip3 install -e git+${GIT_URL}@${GIT_BRANCH}#egg=ckan && \
     cd ${SRC_DIR}/ckan && \
     cp who.ini ${APP_DIR} && \
-    # Workaround, can be removed when 2.10.2 is released
-    # https://github.com/ckan/ckan/pull/7864
-    sed -i 's/pyyaml==6.0/pyyaml==6.0.1/' requirements.txt && \
     pip3 install --no-binary markdown -r requirements.txt && \
     # Install CKAN envvars to support loading config from environment variables
     pip3 install -e git+https://github.com/okfn/ckanext-envvars.git#egg=ckanext-envvars && \

--- a/ckan-2.10/base/Makefile
+++ b/ckan-2.10/base/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all help build build-all push
 SHELL := /bin/bash
-CKAN_VERSION=2.10.1
+CKAN_VERSION=2.10.3
 CKAN_VERSION_MAJOR=$(shell echo $(CKAN_VERSION) | cut -d'.' -f1)
 CKAN_VERSION_MINOR=$(shell echo $(CKAN_VERSION) | cut -d'.' -f2)
 TAG_NAME="ckan/ckan-base:$(CKAN_VERSION)"

--- a/ckan-2.10/dev/Dockerfile
+++ b/ckan-2.10/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM ckan/ckan-base:2.10.1
+FROM ckan/ckan-base:2.10.3
 
 
 ENV APP_DIR=/srv/app

--- a/ckan-2.10/dev/Makefile
+++ b/ckan-2.10/dev/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all help build build-all push
 SHELL := /bin/bash
-CKAN_VERSION=2.10.1
+CKAN_VERSION=2.10.3
 CKAN_VERSION_MAJOR=$(shell echo $(CKAN_VERSION) | cut -d'.' -f1)
 CKAN_VERSION_MINOR=$(shell echo $(CKAN_VERSION) | cut -d'.' -f2)
 TAG_NAME="ckan/ckan-dev:$(CKAN_VERSION)"

--- a/ckan-2.9/base/Dockerfile
+++ b/ckan-2.9/base/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.15
-ARG CKAN_VERSION=ckan-2.9.9
+ARG CKAN_VERSION=ckan-2.9.10
 
 # Internals, you probably don't need to change these
 ENV TZ=UTC
@@ -82,7 +82,7 @@ RUN pip3 install -e git+${GIT_URL}@${GIT_BRANCH}#egg=ckan && \
     # https://github.com/ckan/ckan/pull/7864
     #sed -i 's/pyyaml==6.0/pyyaml==6.0.1/' requirements.txt && \
     # begin workaround
-    sed -i '/pyyaml==5.4.1/d' requirements.txt && \
+    #sed -i '/pyyaml==5.4.1/d' requirements.txt && \
     echo 'Cython < 3.0' > /tmp/constraint.txt && \
     PIP_CONSTRAINT=/tmp/constraint.txt pip3 install PyYAML==5.4.1 && \
     # end workaround

--- a/ckan-2.9/base/Makefile
+++ b/ckan-2.9/base/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all help build build-all push
 SHELL := /bin/bash
 
-CKAN_VERSION=2.9.9
+CKAN_VERSION=2.9.10
 CKAN_VERSION_MAJOR=$(shell echo $(CKAN_VERSION) | cut -d'.' -f1)
 CKAN_VERSION_MINOR=$(shell echo $(CKAN_VERSION) | cut -d'.' -f2)
 TAG_NAME="ckan/ckan-base:$(CKAN_VERSION)"

--- a/ckan-2.9/dev/Dockerfile
+++ b/ckan-2.9/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM ckan/ckan-base:2.9.9
+FROM ckan/ckan-base:2.9.10
 
 
 ENV APP_DIR=/srv/app

--- a/ckan-2.9/dev/Makefile
+++ b/ckan-2.9/dev/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all help build build-all push
 SHELL := /bin/bash
-CKAN_VERSION=2.9.9
+CKAN_VERSION=2.9.10
 CKAN_VERSION_MAJOR=$(shell echo $(CKAN_VERSION) | cut -d'.' -f1)
 CKAN_VERSION_MINOR=$(shell echo $(CKAN_VERSION) | cut -d'.' -f2)
 TAG_NAME="ckan/ckan-dev:$(CKAN_VERSION)"


### PR DESCRIPTION
- Build ckan 2.10.3 and 2.9.10 images
- Push to DockerHub
- Tested containers built off 2.10.3 base and dev images
- Tested containers built off 2.9.10 base and dev images