### PR TITLE
Preserve libmagic

### DIFF
--- a/datapusher/Dockerfile
+++ b/datapusher/Dockerfile
@@ -12,13 +12,13 @@ RUN apk add --no-cache \
     py3-pip \
     py3-wheel \
     libffi-dev \
+    libmagic \
     libressl-dev \
     libxslt \
     uwsgi \
     uwsgi-http \
     uwsgi-corerouter \
     uwsgi-python \
-    libmagic \
     # Temporary packages to build DataPusher requirements
     && apk add --no-cache --virtual .build-deps \
     gcc \

--- a/datapusher/Dockerfile
+++ b/datapusher/Dockerfile
@@ -18,6 +18,7 @@ RUN apk add --no-cache \
     uwsgi-http \
     uwsgi-corerouter \
     uwsgi-python \
+    libmagic \
     # Temporary packages to build DataPusher requirements
     && apk add --no-cache --virtual .build-deps \
     gcc \
@@ -26,7 +27,6 @@ RUN apk add --no-cache \
     python3-dev \
     libxml2-dev \
     libxslt-dev \
-    libmagic \
     openssl-dev \
     cargo
 


### PR DESCRIPTION
`libmagic` is a `messytables` requirement.

I'm getting this error in datapusher

![image](https://github.com/ckan/ckan-docker-base/assets/3237309/e8894715-4f2e-4698-b9e3-aeee9789e3d8)

`apk` packages installed with `--virtual` are removed with `apk del`
It looks like we need this Alpine package to be permanent.