### PR TITLE
Support dev extensions with "pyproject.toml"

### DIFF
--- a/ckan-2.10/dev/setup/start_ckan_development.sh
+++ b/ckan-2.10/dev/setup/start_ckan_development.sh
@@ -37,6 +37,13 @@ do
             echo "Found setup.py file in $i"
             cd $APP_DIR
         fi
+        if [ -f $i/pyproject.toml ];
+        then
+            cd $i
+            pip install -e .
+            echo "Found pyproject.toml file in $i"
+            cd $APP_DIR
+        fi
 
         # Point `use` in test.ini to location of `test-core.ini`
         if [ -f $i/test.ini ];

--- a/ckan-2.9/dev/setup/start_ckan_development.sh
+++ b/ckan-2.9/dev/setup/start_ckan_development.sh
@@ -31,6 +31,13 @@ do
             echo "Found setup.py file in $i"
             cd $APP_DIR
         fi
+        if [ -f $i/pyproject.toml ];
+        then
+            cd $i
+            pip install -e .
+            echo "Found pyproject.toml file in $i"
+            cd $APP_DIR
+        fi
 
         # Point `use` in test.ini to location of `test-core.ini`
         if [ -f $i/test.ini ];

--- a/ckan-master/dev/setup/start_ckan_development.sh
+++ b/ckan-master/dev/setup/start_ckan_development.sh
@@ -37,6 +37,13 @@ do
             echo "Found setup.py file in $i"
             cd $APP_DIR
         fi
+        if [ -f $i/pyproject.toml ];
+        then
+            cd $i
+            pip install -e .
+            echo "Found pyproject.toml file in $i"
+            cd $APP_DIR
+        fi
 
         # Point `use` in test.ini to location of `test-core.ini`
         if [ -f $i/test.ini ];


### PR DESCRIPTION
# Overview

`pyproject.toml` is becoming more and more popular in Python packaging so it would be good if extensions using this approach are supported as well

# Note

Probably `pip install -e .` might be universal command for installing an extension no matter whether it's setup or pyproject based