### PR TITLE
use while loop for restarting dev

### DIFF
--- a/ckan-2.10/dev/setup/start_ckan_development.sh
+++ b/ckan-2.10/dev/setup/start_ckan_development.sh
@@ -92,12 +92,13 @@ then
     done
 fi
 
-# Start supervisord
-supervisord --configuration /etc/supervisord.conf &
-
 # Start the development server as the ckan user with automatic reload
-if [ "$USE_HTTPS_FOR_DEV" = true ] ; then
-    su ckan -c "/usr/bin/ckan -c $CKAN_INI run -H 0.0.0.0 -C unsafe.cert -K unsafe.key"
-else
-    su ckan -c "/usr/bin/ckan -c $CKAN_INI run -H 0.0.0.0"
-fi
+while true; do
+    if [ "$USE_HTTPS_FOR_DEV" = true ] ; then
+        su ckan -c "/usr/bin/ckan -c $CKAN_INI run -H 0.0.0.0 -C unsafe.cert -K unsafe.key"
+    else
+        su ckan -c "/usr/bin/ckan -c $CKAN_INI run -H 0.0.0.0"
+    fi
+    echo Exit with status $?. Restarting.
+    sleep 2
+done

--- a/ckan-2.9/dev/setup/start_ckan_development.sh
+++ b/ckan-2.9/dev/setup/start_ckan_development.sh
@@ -85,12 +85,13 @@ then
     done
 fi
 
-# Start supervisord
-supervisord --configuration /etc/supervisord.conf &
-
 # Start the development server as the ckan user with automatic reload
-if [ "$USE_HTTPS_FOR_DEV" = true ] ; then
-    su ckan -c "/usr/bin/ckan -c $CKAN_INI run -H 0.0.0.0 -C unsafe.cert -K unsafe.key"
-else
-    su ckan -c "/usr/bin/ckan -c $CKAN_INI run -H 0.0.0.0"
-fi
+while true; do
+    if [ "$USE_HTTPS_FOR_DEV" = true ] ; then
+        su ckan -c "/usr/bin/ckan -c $CKAN_INI run -H 0.0.0.0 -C unsafe.cert -K unsafe.key"
+    else
+        su ckan -c "/usr/bin/ckan -c $CKAN_INI run -H 0.0.0.0"
+    fi
+    echo Exit with status $?. Restarting.
+    sleep 2
+done

--- a/ckan-master/dev/setup/start_ckan_development.sh
+++ b/ckan-master/dev/setup/start_ckan_development.sh
@@ -92,12 +92,13 @@ then
     done
 fi
 
-# Start supervisord
-supervisord --configuration /etc/supervisord.conf &
-
 # Start the development server as the ckan user with automatic reload
-if [ "$USE_HTTPS_FOR_DEV" = true ] ; then
-    su ckan -c "/usr/bin/ckan -c $CKAN_INI run -H 0.0.0.0 -C unsafe.cert -K unsafe.key"
-else
-    su ckan -c "/usr/bin/ckan -c $CKAN_INI run -H 0.0.0.0"
-fi
+while true; do
+    if [ "$USE_HTTPS_FOR_DEV" = true ] ; then
+        su ckan -c "/usr/bin/ckan -c $CKAN_INI run -H 0.0.0.0 -C unsafe.cert -K unsafe.key"
+    else
+        su ckan -c "/usr/bin/ckan -c $CKAN_INI run -H 0.0.0.0"
+    fi
+    echo Exit with status $?. Restarting.
+    sleep 2
+done


### PR DESCRIPTION
supervisord is not ideal for a development server.

- if ckan restarts too quickly (e.g. accidental syntax error) supervisor will stop trying to restart the service
- if you want to run ckan from the shell (e.g. for pdb debugging) the start_ckan_development.sh script can't be interrupted with ^C or ^\ making it difficult to forcibly restart or cleanly shut down the container

I've replaced supervisor in the dev environments with a while loop and a short delay so we can see the traceback on restart.