### PR TITLE
debugpy support for VS Code remote debugging

### DIFF
--- a/ckan-2.10/dev/setup/start_ckan_development.sh
+++ b/ckan-2.10/dev/setup/start_ckan_development.sh
@@ -92,13 +92,21 @@ then
     done
 fi
 
+CKAN_RUN="/usr/bin/ckan -c $CKAN_INI run -H 0.0.0.0"
+CKAN_OPTIONS=""
+if [ "$USE_DEBUGPY_FOR_DEV" = true ] ; then
+    pip install debugpy
+    CKAN_RUN="/usr/bin/python -m debugpy --listen 0.0.0.0:5678 $CKAN_RUN"
+    CKAN_OPTIONS="$CKAN_OPTIONS --disable-reloader"
+fi
+
+if [ "$USE_HTTPS_FOR_DEV" = true ] ; then
+    CKAN_OPTIONS="$CKAN_OPTIONS -C unsafe.cert -K unsafe.key"
+fi
+
 # Start the development server as the ckan user with automatic reload
 while true; do
-    if [ "$USE_HTTPS_FOR_DEV" = true ] ; then
-        su ckan -c "/usr/bin/ckan -c $CKAN_INI run -H 0.0.0.0 -C unsafe.cert -K unsafe.key"
-    else
-        su ckan -c "/usr/bin/ckan -c $CKAN_INI run -H 0.0.0.0"
-    fi
+    su ckan -c "$CKAN_RUN $CKAN_OPTIONS"
     echo Exit with status $?. Restarting.
     sleep 2
 done

--- a/ckan-2.10/dev/setup/start_ckan_development.sh
+++ b/ckan-2.10/dev/setup/start_ckan_development.sh
@@ -92,12 +92,13 @@ then
     done
 fi
 
-# Start supervisord
-supervisord --configuration /etc/supervisord.conf &
-
 # Start the development server as the ckan user with automatic reload
-if [ "$USE_HTTPS_FOR_DEV" = true ] ; then
-    su ckan -c "/usr/bin/ckan -c $CKAN_INI run -H 0.0.0.0 -C unsafe.cert -K unsafe.key"
-else
-    su ckan -c "/usr/bin/ckan -c $CKAN_INI run -H 0.0.0.0"
-fi
+while true; do
+    if [ "$USE_HTTPS_FOR_DEV" = true ] ; then
+        su ckan -c "/usr/bin/ckan -c $CKAN_INI run -H 0.0.0.0 -C unsafe.cert -K unsafe.key"
+    else
+        su ckan -c "/usr/bin/ckan -c $CKAN_INI run -H 0.0.0.0"
+    fi
+    echo Exit with status $?. Restarting.
+    sleep 2
+done

--- a/ckan-2.9/dev/setup/start_ckan_development.sh
+++ b/ckan-2.9/dev/setup/start_ckan_development.sh
@@ -85,13 +85,21 @@ then
     done
 fi
 
+CKAN_RUN="/usr/bin/ckan -c $CKAN_INI run -H 0.0.0.0"
+CKAN_OPTIONS=""
+if [ "$USE_DEBUGPY_FOR_DEV" = true ] ; then
+    pip install debugpy
+    CKAN_RUN="/usr/bin/python -m debugpy --listen 0.0.0.0:5678 $CKAN_RUN"
+    CKAN_OPTIONS="$CKAN_OPTIONS --disable-reloader"
+fi
+
+if [ "$USE_HTTPS_FOR_DEV" = true ] ; then
+    CKAN_OPTIONS="$CKAN_OPTIONS -C unsafe.cert -K unsafe.key"
+fi
+
 # Start the development server as the ckan user with automatic reload
 while true; do
-    if [ "$USE_HTTPS_FOR_DEV" = true ] ; then
-        su ckan -c "/usr/bin/ckan -c $CKAN_INI run -H 0.0.0.0 -C unsafe.cert -K unsafe.key"
-    else
-        su ckan -c "/usr/bin/ckan -c $CKAN_INI run -H 0.0.0.0"
-    fi
+    su ckan -c "$CKAN_RUN $CKAN_OPTIONS"
     echo Exit with status $?. Restarting.
     sleep 2
 done

--- a/ckan-2.9/dev/setup/start_ckan_development.sh
+++ b/ckan-2.9/dev/setup/start_ckan_development.sh
@@ -85,12 +85,13 @@ then
     done
 fi
 
-# Start supervisord
-supervisord --configuration /etc/supervisord.conf &
-
 # Start the development server as the ckan user with automatic reload
-if [ "$USE_HTTPS_FOR_DEV" = true ] ; then
-    su ckan -c "/usr/bin/ckan -c $CKAN_INI run -H 0.0.0.0 -C unsafe.cert -K unsafe.key"
-else
-    su ckan -c "/usr/bin/ckan -c $CKAN_INI run -H 0.0.0.0"
-fi
+while true; do
+    if [ "$USE_HTTPS_FOR_DEV" = true ] ; then
+        su ckan -c "/usr/bin/ckan -c $CKAN_INI run -H 0.0.0.0 -C unsafe.cert -K unsafe.key"
+    else
+        su ckan -c "/usr/bin/ckan -c $CKAN_INI run -H 0.0.0.0"
+    fi
+    echo Exit with status $?. Restarting.
+    sleep 2
+done

--- a/ckan-master/dev/setup/start_ckan_development.sh
+++ b/ckan-master/dev/setup/start_ckan_development.sh
@@ -92,13 +92,21 @@ then
     done
 fi
 
+CKAN_RUN="/usr/bin/ckan -c $CKAN_INI run -H 0.0.0.0"
+CKAN_OPTIONS=""
+if [ "$USE_DEBUGPY_FOR_DEV" = true ] ; then
+    pip install debugpy
+    CKAN_RUN="/usr/bin/python -m debugpy --listen 0.0.0.0:5678 $CKAN_RUN"
+    CKAN_OPTIONS="$CKAN_OPTIONS --disable-reloader"
+fi
+
+if [ "$USE_HTTPS_FOR_DEV" = true ] ; then
+    CKAN_OPTIONS="$CKAN_OPTIONS -C unsafe.cert -K unsafe.key"
+fi
+
 # Start the development server as the ckan user with automatic reload
 while true; do
-    if [ "$USE_HTTPS_FOR_DEV" = true ] ; then
-        su ckan -c "/usr/bin/ckan -c $CKAN_INI run -H 0.0.0.0 -C unsafe.cert -K unsafe.key"
-    else
-        su ckan -c "/usr/bin/ckan -c $CKAN_INI run -H 0.0.0.0"
-    fi
+    su ckan -c "$CKAN_RUN $CKAN_OPTIONS"
     echo Exit with status $?. Restarting.
     sleep 2
 done

--- a/ckan-master/dev/setup/start_ckan_development.sh
+++ b/ckan-master/dev/setup/start_ckan_development.sh
@@ -92,12 +92,13 @@ then
     done
 fi
 
-# Start supervisord
-supervisord --configuration /etc/supervisord.conf &
-
 # Start the development server as the ckan user with automatic reload
-if [ "$USE_HTTPS_FOR_DEV" = true ] ; then
-    su ckan -c "/usr/bin/ckan -c $CKAN_INI run -H 0.0.0.0 -C unsafe.cert -K unsafe.key"
-else
-    su ckan -c "/usr/bin/ckan -c $CKAN_INI run -H 0.0.0.0"
-fi
+while true; do
+    if [ "$USE_HTTPS_FOR_DEV" = true ] ; then
+        su ckan -c "/usr/bin/ckan -c $CKAN_INI run -H 0.0.0.0 -C unsafe.cert -K unsafe.key"
+    else
+        su ckan -c "/usr/bin/ckan -c $CKAN_INI run -H 0.0.0.0"
+    fi
+    echo Exit with status $?. Restarting.
+    sleep 2
+done


### PR DESCRIPTION
Includes the changes from #49, please review that one first

Adds a new option `USE_DEBUGPY_FOR_DEV` that when set to `true` will install and run ckan under debugby so that VS Code can attach to the running process for remote debugging.