### PR TITLE
uninstall src packages found in src_extensions

### DIFF
--- a/ckan-2.10/dev/setup/start_ckan_development.sh
+++ b/ckan-2.10/dev/setup/start_ckan_development.sh
@@ -14,6 +14,10 @@ for i in $SRC_EXTENSIONS_DIR/*
 do
     if [ -d $i ];
     then
+    	if [ -d $SRC_DIR/$(basename $i) ];
+        then
+            pip uninstall -y "$(basename $i)"
+        fi
 
         if [ -f $i/pip-requirements.txt ];
         then

--- a/ckan-2.9/dev/setup/start_ckan_development.sh
+++ b/ckan-2.9/dev/setup/start_ckan_development.sh
@@ -8,6 +8,10 @@ for i in $SRC_EXTENSIONS_DIR/*
 do
     if [ -d $i ];
     then
+    	if [ -d $SRC_DIR/$(basename $i) ];
+        then
+            pip uninstall -y "$(basename $i)"
+        fi
 
         if [ -f $i/pip-requirements.txt ];
         then

--- a/ckan-master/dev/setup/start_ckan_development.sh
+++ b/ckan-master/dev/setup/start_ckan_development.sh
@@ -14,6 +14,10 @@ for i in $SRC_EXTENSIONS_DIR/*
 do
     if [ -d $i ];
     then
+    	if [ -d $SRC_DIR/$(basename $i) ];
+        then
+            pip uninstall -y "$(basename $i)"
+        fi
 
         if [ -f $i/pip-requirements.txt ];
         then


### PR DESCRIPTION
ckan-docker-base has `ckan` and `ckanext-envvars` installed under `src` with additional packages installed under `src_extensions` (mapping to a local `src` directory, confusingly)

If you have a copy of `ckan` or `ckanext-envvars` in `src_extensions` they will be installed, but not completely because the entry points from the ckan-docker-base packages won't be updated.

This PR uninstalls any existing `src` package if a directory with the same name is in `src_extensions` so that the entry points for development versions of packages are updated correctly.