### PR TITLE
Upgrade db like the console text says

### DIFF
--- a/ckan-2.10/base/setup/prerun.py
+++ b/ckan-2.10/base/setup/prerun.py
@@ -96,7 +96,7 @@ def check_solr_connection(retry=None):
 
 def init_db():
 
-    db_command = ["ckan", "-c", ckan_ini, "db", "init"]
+    db_command = ["ckan", "-c", ckan_ini, "db", "upgrade"]
     print("[prerun] Initializing or upgrading db - start")
     try:
         subprocess.check_output(db_command, stderr=subprocess.STDOUT)

--- a/ckan-2.9/base/setup/prerun.py
+++ b/ckan-2.9/base/setup/prerun.py
@@ -96,7 +96,7 @@ def check_solr_connection(retry=None):
 
 def init_db():
 
-    db_command = ["ckan", "-c", ckan_ini, "db", "init"]
+    db_command = ["ckan", "-c", ckan_ini, "db", "upgrade"]
     print("[prerun] Initializing or upgrading db - start")
     try:
         subprocess.check_output(db_command, stderr=subprocess.STDOUT)

--- a/ckan-master/base/setup/prerun.py
+++ b/ckan-master/base/setup/prerun.py
@@ -96,7 +96,7 @@ def check_solr_connection(retry=None):
 
 def init_db():
 
-    db_command = ["ckan", "-c", ckan_ini, "db", "init"]
+    db_command = ["ckan", "-c", ckan_ini, "db", "upgrade"]
     print("[prerun] Initializing or upgrading db - start")
     try:
         subprocess.check_output(db_command, stderr=subprocess.STDOUT)


### PR DESCRIPTION
on ckan master this also applies extension upgrades (like the required activities migration) whereas `db init` does not.