### PR TITLE
fix for master packaging uninstall error

### DIFF
--- a/ckan-master/base/Dockerfile
+++ b/ckan-master/base/Dockerfile
@@ -40,8 +40,6 @@ RUN apk add --no-cache git \
         uwsgi-http \
         uwsgi-corerouter \
         uwsgi-python \
-        py3-gevent \
-        uwsgi-gevent \
         libmagic \
         curl \
         patch \


### PR DESCRIPTION
Since https://github.com/ckan/ckan/pull/7893 installing requirements from a local copy of ckan in `src` fails trying to uninstall `packaging`, which was installed a requirement of the system package `py3-gevent` (not via pip), so pip can't uninstall it.

AFAICT we don't use `py3-gevent` so I'm removing it and `uwsgi-gevent` from the install here.