### PR TITLE
Bump DataPusher version (0.0.21) and DataPusher and CKAN to listen on ipv6 addresses

### DIFF
--- a/ckan-2.10/base/setup/start_ckan.sh
+++ b/ckan-2.10/base/setup/start_ckan.sh
@@ -39,7 +39,7 @@ UWSGI_OPTS="--plugins http,python \
             --wsgi-file /srv/app/wsgi.py \
             --module wsgi:application \
             --uid 92 --gid 92 \
-            --http 0.0.0.0:5000 \
+            --http [::]:5000 \
             --master --enable-threads \
             --lazy-apps \
             -p 2 -L -b 32768 --vacuum \

--- a/ckan-master/base/setup/start_ckan.sh
+++ b/ckan-master/base/setup/start_ckan.sh
@@ -39,7 +39,7 @@ UWSGI_OPTS="--plugins http,python \
             --wsgi-file /srv/app/wsgi.py \
             --module wsgi:application \
             --uid 92 --gid 92 \
-            --http 0.0.0.0:5000 \
+            --http [::]:5000 \
             --master --enable-threads \
             --lazy-apps \
             -p 2 -L -b 32768 --vacuum \

--- a/datapusher/Dockerfile
+++ b/datapusher/Dockerfile
@@ -1,11 +1,17 @@
 FROM alpine:3.14
 
 ARG DATAPUSHER_VERSION=${DATAPUSHER_VERSION}
+
+ENV TZ=UTC
 ENV APP_DIR=/srv/app
 ENV GIT_URL https://github.com/ckan/datapusher.git
 ENV JOB_CONFIG ${APP_DIR}/datapusher_settings.py
 
 WORKDIR ${APP_DIR}
+
+# Set up timezone
+RUN apk add --no-cache tzdata
+RUN echo ${TZ} > /etc/timezone
 
 RUN apk add --no-cache \
     python3 \
@@ -55,4 +61,4 @@ USER ckan
 
 EXPOSE 8800
 CMD ["sh", "-c", \
-    "uwsgi --plugins=http,python --enable-threads --http=0.0.0.0:8800 --socket=/tmp/uwsgi.sock --ini=`echo ${APP_DIR}`/datapusher-uwsgi.ini --wsgi-file=`echo ${APP_DIR}`/datapusher.wsgi"]
+    "uwsgi --plugins=http,python --enable-threads --http=[::]:8800 --socket=/tmp/uwsgi.sock --ini=`echo ${APP_DIR}`/datapusher-uwsgi.ini --wsgi-file=`echo ${APP_DIR}`/datapusher.wsgi"]

--- a/datapusher/Makefile
+++ b/datapusher/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all help build build-all push
 SHELL := /bin/bash
-DATAPUSHER_VERSION=0.0.20
+DATAPUSHER_VERSION=0.0.21
 TAG_NAME="ckan/ckan-base-datapusher:$(DATAPUSHER_VERSION)"
 
 all: help


### PR DESCRIPTION
- Bump DataPusher version to **0.0.21**
- Listen on an IPv6 unspecified address for DataPusher and CKAN (rather than IPv4) [related issue](https://github.com/ckan/ckan-docker-base/issues/65)
- Set UTC timezone to get rid of warning messages