### PR TITLE
example entrypoint to enable virtualenv

### DIFF
--- a/ckan-master/base/Dockerfile
+++ b/ckan-master/base/Dockerfile
@@ -78,8 +78,10 @@ RUN groupadd -g 92 ckan && \
 
 COPY setup/prerun.py ${APP_DIR}
 COPY setup/start_ckan.sh ${APP_DIR}
+COPY setup/entrypoint.sh ${APP_DIR}
 ADD https://raw.githubusercontent.com/ckan/ckan/${CKAN_TAG}/wsgi.py ${APP_DIR}
 RUN chmod 644 ${APP_DIR}/wsgi.py
+RUN chmod +x ${APP_DIR}/entrypoint.sh
 
 # Create entrypoint directory for children image scripts
 ONBUILD RUN mkdir /docker-entrypoint.d
@@ -88,4 +90,5 @@ EXPOSE 5000
 
 HEALTHCHECK --interval=60s --timeout=5s --retries=5 CMD curl --fail http://localhost:5000/api/3/action/status_show || exit CMD ["/srv/app/start_ckan.sh"]
 
+ENTRYPOINT ["/srv/app/entrypoint.sh"]
 CMD ["/srv/app/start_ckan.sh"]

--- a/ckan-master/base/setup/entrypoint.sh
+++ b/ckan-master/base/setup/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+APP_DIR=/srv/app
+
+# Source the Python virtual environment
+source $APP_DIR/bin/activate
+
+# run CMD passed
+$@


### PR DESCRIPTION
Here's a quick example of entrypoint usage to run commands before user-provided ones.

Here I've only activated the virtualenv, maybe we the SECRET_KEY auto-setting logic here so we can run commands like
```bash
docker-compose run ckan ckan sysadmin add …
```