### PR TITLE
Add Debian-based Python images for CKAN 2.9 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The following CKAN versions are available in base or dev forms. They are disting
 | --- | --- | --- | --- | --- |
 | 2.9.x  | base image | `alpine:3.15`               | `ckan/ckan-base:2.9.11`, `ckan/ckan-base:2.9`           |  |
 | 2.9.x  | dev image  | `alpine:3.15`               | `ckan/ckan-dev:2.9.11`, `ckan/ckan-dev:2.9`             |  |
+| 2.9.x | base image | `python:3.9-slim-bookworm` | `ckan/ckan-base:2.9-py3.9`, `ckan/ckan-base:2.9.4-py3.9`                            |  |
+| 2.9.x | dev image  | `python:3.9-slim-bookworm` | `ckan/ckan-dev:2.9-py3.9`, `ckan/ckan-dev:2.9.4-py3.9`                             |  |
 | 2.10.x | base image | `alpine:3.17`               | `ckan/ckan-base:2.10.4`, `ckan/ckan-base:2.10`          |  |
 | 2.10.x | dev image  | `alpine:3.17`               | `ckan/ckan-dev:2.10.4`, `ckan/ckan-dev:2.10`            |  |
 | 2.10.x | base image | `python:3.10-slim-bookworm` | `ckan/ckan-base:2.10-py3.10`, `ckan/ckan-base:2.10.4-py3.10`                            |  |

--- a/ckan-2.9/base/Dockerfile
+++ b/ckan-2.9/base/Dockerfile
@@ -34,6 +34,7 @@ RUN apk add --no-cache git \
         gettext \
         postgresql-client \
         python3 \
+        py3-pip \
         libxml2 \
         libxslt \
         musl-dev \
@@ -65,6 +66,7 @@ RUN apk add --no-cache git \
     # Create SRC_DIR
     mkdir -p ${SRC_DIR} && \
     # Install pip, supervisord and uwsgi
+    pip3 install "webassets==0.12.1" && \
     curl -o ${SRC_DIR}/get-pip.py https://bootstrap.pypa.io/get-pip.py && \
     python3 ${SRC_DIR}/get-pip.py && \
     pip3 install supervisor && \
@@ -78,13 +80,9 @@ COPY setup/supervisord.conf /etc
 RUN pip3 install -e git+${GIT_URL}@${GIT_BRANCH}#egg=ckan && \
     cd ${SRC_DIR}/ckan && \
     cp who.ini ${APP_DIR} && \
-    # Workaround, can be removed when 2.10.2 is released
-    # https://github.com/ckan/ckan/pull/7864
-    #sed -i 's/pyyaml==6.0/pyyaml==6.0.1/' requirements.txt && \
     # begin workaround
-    #sed -i '/pyyaml==5.4.1/d' requirements.txt && \
-    echo 'Cython < 3.0' > /tmp/constraint.txt && \
-    PIP_CONSTRAINT=/tmp/constraint.txt pip3 install PyYAML==5.4.1 && \
+    pip3 install "cython<3.0.0" && \
+    pip3 install "pyyaml==5.4.1" --no-build-isolation && \
     # end workaround
     pip3 install -r requirement-setuptools.txt && \
     pip3 install --no-binary markdown -r requirements.txt && \

--- a/ckan-2.9/base/Dockerfile.py3.9
+++ b/ckan-2.9/base/Dockerfile.py3.9
@@ -1,0 +1,95 @@
+FROM python:3.9-slim-bookworm
+
+# Tag passed through via the Makefile
+ARG CKAN_TAG=${CKAN_TAG}
+
+ENV TZ=UTC
+ENV APP_DIR=/srv/app
+ENV SRC_DIR=${APP_DIR}/src
+ENV CKAN_INI=${APP_DIR}/ckan.ini
+ENV PIP_SRC=${SRC_DIR}
+ENV CKAN_STORAGE_PATH=/var/lib/ckan
+ENV GIT_URL=https://github.com/ckan/ckan.git
+
+# Customize these in the environment (.env) file if needed
+ENV CKAN_SITE_URL=http://localhost:5000
+ENV CKAN__PLUGINS="image_view text_view recline_view datastore envvars"
+
+# UWSGI options
+ENV UWSGI_HARAKIRI=50
+
+WORKDIR ${APP_DIR}
+
+# Set up timezone
+RUN echo ${TZ} > /etc/timezone
+
+# Set LC_ALL=en_US.UTF-8 will ensure that all locale-dependent operations in the current environment 
+# will use English language and United States cultural conventions with UTF-8 character encoding
+ENV LC_ALL=en_US.UTF-8
+
+# Set the locale          
+RUN apt-get update
+RUN apt-get install --no-install-recommends -y locales
+RUN sed -i "/$LC_ALL/s/^# //g" /etc/locale.gen
+RUN dpkg-reconfigure --frontend=noninteractive locales 
+RUN update-locale LANG=${LC_ALL}
+
+# Install system libraries
+RUN apt-get install --no-install-recommends -y \
+        apt-utils \
+        git \
+        libpq-dev \
+        g++ \
+        linux-headers-generic \
+        libtool \
+        wget
+
+# Create the src directory
+RUN mkdir -p ${SRC_DIR}
+
+# Install supervisord and create the supervisord.d directory
+RUN apt-get install --no-install-recommends -y \
+        supervisor && \
+        mkdir /etc/supervisord.d
+
+COPY setup/supervisord.conf /etc
+
+# Install uwsgi, the CKAN application, the dependency packages for CKAN plus some confiquration
+
+RUN pip3 install "webassets==0.12.1" && \
+    pip3 install -U pip && \
+    pip3 install uwsgi && \
+    cd ${SRC_DIR} && \
+    pip3 install -e git+${GIT_URL}@${CKAN_TAG}#egg=ckan && \
+    cd ckan && \
+    cp who.ini ${APP_DIR} && \
+    pip3 install "cython<3.0.0" && \
+    pip3 install "pyyaml==5.4.1" --no-build-isolation && \
+    pip3 install -r requirement-setuptools.txt && \
+    pip3 install --no-binary markdown -r requirements.txt && \
+    # Install CKAN envvars to support loading config from environment variables
+    pip3 install -e git+https://github.com/okfn/ckanext-envvars.git#egg=ckanext-envvars && \
+    # Create and update CKAN config
+    ckan generate config ${CKAN_INI} && \
+    ckan config-tool ${CKAN_INI} "beaker.session.secret = " && \
+    ckan config-tool ${CKAN_INI} "ckan.plugins = ${CKAN__PLUGINS}"
+
+# Create a local user and group plus set up the storage path
+RUN groupadd -g 92 ckan && \
+    useradd -rm -d /srv/app -s /bin/bash -g ckan -u 92 ckan && \
+    mkdir -p ${CKAN_STORAGE_PATH} && \
+    chown -R ckan:ckan ${CKAN_STORAGE_PATH}
+
+COPY setup/prerun.py ${APP_DIR}
+COPY setup/start_ckan.sh ${APP_DIR}
+ADD https://raw.githubusercontent.com/ckan/ckan/${CKAN_TAG}/wsgi.py ${APP_DIR}
+RUN chmod 644 ${APP_DIR}/wsgi.py
+
+# Create entrypoint directory for children image scripts
+ONBUILD RUN mkdir /docker-entrypoint.d
+
+EXPOSE 5000
+
+HEALTHCHECK --interval=60s --timeout=5s --retries=5 CMD curl --fail http://localhost:5000/api/3/action/status_show || exit CMD ["/srv/app/start_ckan.sh"]
+
+CMD ["/srv/app/start_ckan.sh"]

--- a/ckan-2.9/base/Makefile
+++ b/ckan-2.9/base/Makefile
@@ -1,23 +1,30 @@
 .PHONY: all help build build-all push
 SHELL := /bin/bash
-
 CKAN_VERSION=2.9.11
+PYTHON_VERSION=3.9
+PYTHON.DOCKERFILE=Dockerfile.py$(PYTHON_VERSION)
 CKAN_VERSION_MAJOR=$(shell echo $(CKAN_VERSION) | cut -d'.' -f1)
 CKAN_VERSION_MINOR=$(shell echo $(CKAN_VERSION) | cut -d'.' -f2)
 TAG_NAME="ckan/ckan-base:$(CKAN_VERSION)"
 ALT_TAG_NAME="ckan/ckan-base:$(CKAN_VERSION_MAJOR).$(CKAN_VERSION_MINOR)"
+PYTHON_TAG_NAME="ckan/ckan-base:$(CKAN_VERSION)-py$(PYTHON_VERSION)"
+PYTHON_ALT_TAG_NAME="ckan/ckan-base:$(CKAN_VERSION_MAJOR).$(CKAN_VERSION_MINOR)-py$(PYTHON_VERSION)"
 
 all: help
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-
-build:	## Build a CKAN 2.x.x image , `make build`
-	echo "Building $(TAG_NAME) and $(ALT_TAG_NAME) images"
+build:	## Build CKAN 2.x.x images , `make build`
+	echo "Building $(TAG_NAME) and $(ALT_TAG_NAME) and $(PYTHON_TAG_NAME) images"
 	docker build --build-arg="CKAN_VERSION=ckan-$(CKAN_VERSION)" -t $(TAG_NAME) -t $(ALT_TAG_NAME) .
+	docker build --build-arg="CKAN_TAG=ckan-$(CKAN_VERSION)" -t $(PYTHON_TAG_NAME) -t $(PYTHON_ALT_TAG_NAME) -f $(PYTHON.DOCKERFILE) .
 
-push: ## Push a CKAN 2.x.x image to the DockerHub registry, `make push`
+push: ## Push CKAN 2.x.x images to the DockerHub registry, `make push`
 	echo "Pushing $(TAG_NAME) image"
 	docker push $(TAG_NAME)
 	echo "Pushing $(ALT_TAG_NAME) image"
 	docker push $(ALT_TAG_NAME)
+	echo "Pushing $(PYTHON_TAG_NAME) image"
+	docker push $(PYTHON_TAG_NAME)
+	echo "Pushing $(PYTHON_ALT_TAG_NAME) image"
+	docker push $(PYTHON_ALT_TAG_NAME)

--- a/ckan-2.9/dev/Dockerfile.py3.9
+++ b/ckan-2.9/dev/Dockerfile.py3.9
@@ -1,0 +1,22 @@
+FROM ckan/ckan-base:2.9.11-py3.10
+
+# Tag passed through via the Makefile
+ARG CKAN_TAG=${CKAN_TAG}
+
+ENV APP_DIR=/srv/app
+ENV SRC_EXTENSIONS_DIR=${APP_DIR}/src_extensions
+
+# Install CKAN dev requirements
+#RUN . ${APP_DIR}/bin/activate && \
+RUN cd ${SRC_DIR}/ckan && \ 
+pip3 install -r https://raw.githubusercontent.com/ckan/ckan/${CKAN_TAG}/dev-requirements.txt
+
+# Create folder for local extensions sources
+RUN mkdir -p ${SRC_EXTENSIONS_DIR}
+
+# These are used to run https on development mode
+COPY setup/unsafe.cert setup/unsafe.key ${APP_DIR}
+
+COPY setup/start_ckan_development.sh ${APP_DIR}
+
+CMD ["/srv/app/start_ckan_development.sh"]

--- a/ckan-2.9/dev/Makefile
+++ b/ckan-2.9/dev/Makefile
@@ -1,10 +1,14 @@
 .PHONY: all help build build-all push
 SHELL := /bin/bash
 CKAN_VERSION=2.9.11
+PYTHON_VERSION=3.9
+PYTHON.DOCKERFILE=Dockerfile.py$(PYTHON_VERSION)
 CKAN_VERSION_MAJOR=$(shell echo $(CKAN_VERSION) | cut -d'.' -f1)
 CKAN_VERSION_MINOR=$(shell echo $(CKAN_VERSION) | cut -d'.' -f2)
 TAG_NAME="ckan/ckan-dev:$(CKAN_VERSION)"
 ALT_TAG_NAME="ckan/ckan-dev:$(CKAN_VERSION_MAJOR).$(CKAN_VERSION_MINOR)"
+PYTHON_TAG_NAME="ckan/ckan-dev:$(CKAN_VERSION)-py$(PYTHON_VERSION)"
+PYTHON_ALT_TAG_NAME="ckan/ckan-dev:$(CKAN_VERSION_MAJOR).$(CKAN_VERSION_MINOR)-py$(PYTHON_VERSION)"
 
 all: help
 help:
@@ -13,11 +17,14 @@ help:
 build:	## Build a CKAN 2.x-dev image , `make build`
 	echo "Building $(TAG_NAME) and $(ALT_TAG_NAME) images"
 	docker build --build-arg="CKAN_VERSION=ckan-$(CKAN_VERSION)" -t $(TAG_NAME) -t $(ALT_TAG_NAME) .
+	docker build --build-arg="CKAN_TAG=ckan-$(CKAN_VERSION)" -t $(PYTHON_TAG_NAME) -t $(PYTHON_ALT_TAG_NAME) -f $(PYTHON.DOCKERFILE) --no-cache .
 
 push: ## Push a CKAN 2.x-dev image to the DockerHub registry, `make push`
 	echo "Pushing $(TAG_NAME) image"
 	docker push $(TAG_NAME)
 	echo "Pushing $(ALT_TAG_NAME) image"
 	docker push $(ALT_TAG_NAME)
-
-
+	echo "Pushing $(PYTHON_TAG_NAME) image"
+	docker push $(PYTHON_TAG_NAME)
+	echo "Pushing $(PYTHON_ALT_TAG_NAME) image"
+	docker push $(PYTHON_ALT_TAG_NAME)

--- a/ckan-2.9/dev/setup/start_ckan_development.sh
+++ b/ckan-2.9/dev/setup/start_ckan_development.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+if [[ $CKAN__PLUGINS == *"datapusher"* ]]; then
+    # Add ckan.datapusher.api_token to the CKAN config file (updated with corrected value later)
+    echo "Setting a temporary value for ckan.datapusher.api_token"
+    ckan config-tool $CKAN_INI ckan.datapusher.api_token=xxx
+fi
+
 # Install any local extensions in the src_extensions volume
 echo "Looking for local extensions to install..."
 echo "Extension dir contents:"
@@ -96,7 +102,7 @@ then
     done
 fi
 
-CKAN_RUN="/usr/bin/ckan -c $CKAN_INI run -H 0.0.0.0"
+CKAN_RUN="ckan -c $CKAN_INI run -H 0.0.0.0"
 CKAN_OPTIONS=""
 if [ "$USE_DEBUGPY_FOR_DEV" = true ] ; then
     pip install debugpy


### PR DESCRIPTION
2.9 will soon stop being supported but hopefully this will help users transition to newer versions (both of CKAN and of the Docker images)

Had to use Python 3.9 because CKAN 2.9 is not 3.10 compatible