### PR TITLE
Update Dockerfile.py3.9 for CKAN 2.9 (dev)

### DIFF
--- a/ckan-2.9/dev/Dockerfile.py3.9
+++ b/ckan-2.9/dev/Dockerfile.py3.9
@@ -1,4 +1,4 @@
-FROM ckan/ckan-base:2.9.11-py3.10
+FROM ckan/ckan-base:2.9.11-py3.9
 
 # Tag passed through via the Makefile
 ARG CKAN_TAG=${CKAN_TAG}


### PR DESCRIPTION
In CKAN **2.9** (**dev**) use `ckan/ckan-base:2.9.11-py3.9` for the base image (rather than `.py3.10`)