### PR TITLE
Fix GitHub Actions permission issues by defaulting Dev images to run as the root user

### DIFF
--- a/ckan-2.10/Dockerfile.py3.10
+++ b/ckan-2.10/Dockerfile.py3.10
@@ -85,24 +85,24 @@ RUN pip3 install -U pip && \
     ckan config-tool ${CKAN_INI} "beaker.session.secret = " && \
     ckan config-tool ${CKAN_INI} "ckan.plugins = ${CKAN__PLUGINS}"
 
+# Create entrypoint directory for children image scripts
+RUN mkdir -p /docker-entrypoint.d && chmod 755 /docker-entrypoint.d
+
 # Create ckan and ckan-sys users and the ckan-sys group plus set up the storage path
 RUN groupadd -g 502 ckan-sys && \
     useradd -rm -d /srv/app -s /bin/bash -g ckan-sys -u 502 ckan-sys && \
     useradd -rm -d /srv/app -s /bin/bash -g ckan-sys -u 503 ckan
-    
+
 COPY setup/prerun.py ${APP_DIR}
 COPY setup/start_ckan.sh ${APP_DIR}
 ADD https://raw.githubusercontent.com/ckan/ckan/${CKAN_REF}/wsgi.py ${APP_DIR}
 RUN chmod 644 ${APP_DIR}/wsgi.py
 
-# Create entrypoint directory for children image scripts
-RUN mkdir -p /docker-entrypoint.d && chmod 755 /docker-entrypoint.d
-
 # Set the ownership of the app directory, usr/local and the entrypoint directory to the ckan-sys user
 RUN chown -R ckan-sys:ckan-sys ${APP_DIR} && \
     chown -R ckan-sys:ckan-sys /docker-entrypoint.d && \
     chown -R ckan-sys:ckan-sys /usr/local
-
+    
 # Set the ownership of the CKAN config file, src and the storage path to the ckan user
 RUN chown ckan:ckan-sys ${APP_DIR}/ckan.ini && \
     chown -R ckan:ckan-sys ${APP_DIR}/src && \
@@ -133,24 +133,42 @@ ENV SRC_EXTENSIONS_DIR=${APP_DIR}/src_extensions
 
 USER root
 
-# Install CKAN dev requirements
-RUN cd ${SRC_DIR}/ckan && \ 
+RUN cd ${SRC_DIR}/ckan && \
 pip3 install -r https://raw.githubusercontent.com/ckan/ckan/${CKAN_REF}/dev-requirements.txt
 
-COPY --chown=ckan-sys:ckan-sys setup/unsafe.cert setup/unsafe.key setup/start_ckan_development.sh setup/install_src.sh ${APP_DIR}
+# These are used to run https on development mode
+COPY setup/unsafe.cert setup/unsafe.key setup/start_ckan_development.sh setup/install_src.sh ${APP_DIR}
 
-# Update local directories
-RUN mkdir -p ${SRC_EXTENSIONS_DIR} /var/lib/ckan && \
-    chown -R ckan-sys:ckan-sys ${SRC_EXTENSIONS_DIR} && \
-    chown -R ckan:ckan-sys /var/lib/ckan/ && \
-    chmod 775 ${SRC_EXTENSIONS_DIR}
-
-USER ckan
+# Create folder for local extensions sources
+RUN mkdir -p ${SRC_EXTENSIONS_DIR}
 
 CMD ["/srv/app/start_ckan_development.sh"]
 
 
-# ──────────────────────────────────────────────────────────────
+## When a non-root user is used for Dev the following code will be needed and the above code will be removed
 
+#FROM base AS dev
+
+#ENV SRC_EXTENSIONS_DIR=${APP_DIR}/src_extensions
+
+#USER root
+
+# Install CKAN dev requirements
+#RUN cd ${SRC_DIR}/ckan && \ 
+#pip3 install -r https://raw.githubusercontent.com/ckan/ckan/${CKAN_REF}/dev-requirements.txt
+
+#COPY --chown=ckan-sys:ckan-sys setup/unsafe.cert setup/unsafe.key setup/start_ckan_development.sh setup/install_src.sh ${APP_DIR}
+
+# Update local directories
+#RUN mkdir -p ${SRC_EXTENSIONS_DIR} /var/lib/ckan && \
+#    chown -R ckan-sys:ckan-sys ${SRC_EXTENSIONS_DIR} && \
+#    chown -R ckan:ckan-sys /var/lib/ckan/ && \
+#    chmod 775 ${SRC_EXTENSIONS_DIR}
+
+#USER ckan
+
+#CMD ["/srv/app/start_ckan_development.sh"]
+
+# ──────────────────────────────────────────────────────────────
 
 FROM ${ENV} AS final

--- a/ckan-2.11/Dockerfile
+++ b/ckan-2.11/Dockerfile
@@ -78,6 +78,9 @@ RUN pip3 install -U pip && \
     ckan config-tool ${CKAN_INI} "SECRET_KEY = " && \
     ckan config-tool ${CKAN_INI} "ckan.plugins = ${CKAN__PLUGINS}"
 
+# Create entrypoint directory for children image scripts
+RUN mkdir -p /docker-entrypoint.d && chmod 755 /docker-entrypoint.d
+
 # Create ckan and ckan-sys users and the ckan-sys group plus set up the storage path
 RUN groupadd -g 502 ckan-sys && \
     useradd -rm -d /srv/app -s /bin/bash -g ckan-sys -u 502 ckan-sys && \
@@ -92,9 +95,6 @@ COPY setup/prerun.py ${APP_DIR}
 COPY setup/start_ckan.sh ${APP_DIR}
 ADD https://raw.githubusercontent.com/ckan/ckan/${CKAN_REF}/wsgi.py ${APP_DIR}
 RUN chmod 644 ${APP_DIR}/wsgi.py
-
-# Create entrypoint directory for children image scripts
-RUN mkdir -p /docker-entrypoint.d && chmod 755 /docker-entrypoint.d
 
 # Set the ownership of the app directory, usr/local and the entrypoint directory to the ckan-sys user
 RUN chown -R ckan-sys:ckan-sys ${APP_DIR} && \
@@ -132,20 +132,38 @@ USER root
 RUN cd ${SRC_DIR}/ckan && \
 pip3 install -r https://raw.githubusercontent.com/ckan/ckan/${CKAN_REF}/dev-requirements.txt
 
-COPY --chown=ckan-sys:ckan-sys setup/unsafe.cert setup/unsafe.key setup/start_ckan_development.sh setup/install_src.sh ${APP_DIR}
+# These are used to run https on development mode
+COPY setup/unsafe.cert setup/unsafe.key setup/start_ckan_development.sh setup/install_src.sh ${APP_DIR}
 
-# Update local directories
-RUN mkdir -p ${SRC_EXTENSIONS_DIR} /var/lib/ckan && \
-    chown -R ckan-sys:ckan-sys ${SRC_EXTENSIONS_DIR} && \
-    chown -R ckan:ckan-sys /var/lib/ckan/ && \
-    chmod 775 ${SRC_EXTENSIONS_DIR}
-
-USER ckan
+# Create folder for local extensions sources
+RUN mkdir -p ${SRC_EXTENSIONS_DIR}
 
 CMD ["/srv/app/start_ckan_development.sh"]
 
 
-# ──────────────────────────────────────────────────────────────
+## When a non-root user is used for Dev the following code will be needed and the above code will be removed
 
+#FROM base AS dev
+
+#ENV SRC_EXTENSIONS_DIR=${APP_DIR}/src_extensions
+
+#USER root
+
+#RUN cd ${SRC_DIR}/ckan && \
+#pip3 install -r https://raw.githubusercontent.com/ckan/ckan/${CKAN_REF}/dev-requirements.txt
+
+#COPY --chown=ckan-sys:ckan-sys setup/unsafe.cert setup/unsafe.key setup/start_ckan_development.sh setup/install_src.sh ${APP_DIR}
+
+# Update local directories
+#RUN mkdir -p ${SRC_EXTENSIONS_DIR} /var/lib/ckan && \
+#    chown -R ckan-sys:ckan-sys ${SRC_EXTENSIONS_DIR} && \
+#    chown -R ckan:ckan-sys /var/lib/ckan/ && \
+#    chmod 775 ${SRC_EXTENSIONS_DIR}
+
+#USER ckan
+
+#CMD ["/srv/app/start_ckan_development.sh"]
+
+# ──────────────────────────────────────────────────────────────
 
 FROM ${ENV} AS final

--- a/ckan-2.9/Dockerfile.py3.9
+++ b/ckan-2.9/Dockerfile.py3.9
@@ -91,6 +91,9 @@ RUN pip3 install "webassets==0.12.1" && \
     ckan config-tool ${CKAN_INI} "beaker.session.secret = " && \
     ckan config-tool ${CKAN_INI} "ckan.plugins = ${CKAN__PLUGINS}"
 
+    # Create entrypoint directory for children image scripts
+RUN mkdir -p /docker-entrypoint.d && chmod 755 /docker-entrypoint.d
+
 # Create ckan and ckan-sys users and the ckan-sys group plus set up the storage path
 RUN groupadd -g 502 ckan-sys && \
     useradd -rm -d /srv/app -s /bin/bash -g ckan-sys -u 502 ckan-sys && \
@@ -100,9 +103,6 @@ COPY setup/prerun.py ${APP_DIR}
 COPY setup/start_ckan.sh ${APP_DIR}
 ADD https://raw.githubusercontent.com/ckan/ckan/${CKAN_REF}/wsgi.py ${APP_DIR}
 RUN chmod 644 ${APP_DIR}/wsgi.py
-
-# Create entrypoint directory for children image scripts
-RUN mkdir -p /docker-entrypoint.d && chmod 755 /docker-entrypoint.d
 
 # Set the ownership of the app directory, usr/local and the entrypoint directory to the ckan-sys user
 RUN chown -R ckan-sys:ckan-sys ${APP_DIR} && \
@@ -138,25 +138,41 @@ ENV SRC_EXTENSIONS_DIR=${APP_DIR}/src_extensions
 
 USER root
 
-# Install CKAN dev requirements
-#RUN . ${APP_DIR}/bin/activate && \
 RUN cd ${SRC_DIR}/ckan && \ 
 pip3 install -r https://raw.githubusercontent.com/ckan/ckan/${CKAN_REF}/dev-requirements.txt
 
-COPY --chown=ckan-sys:ckan-sys setup/unsafe.cert setup/unsafe.key setup/start_ckan_development.sh setup/install_src.sh ${APP_DIR}
+# These are used to run https on development mode
+COPY setup/unsafe.cert setup/unsafe.key setup/start_ckan_development.sh ${APP_DIR}
 
-# Update local directories
-RUN mkdir -p ${SRC_EXTENSIONS_DIR} /var/lib/ckan && \
-    chown -R ckan-sys:ckan-sys ${SRC_EXTENSIONS_DIR} && \
-    chown -R ckan:ckan-sys /var/lib/ckan/ && \
-    chmod 775 ${SRC_EXTENSIONS_DIR}
-
-USER ckan
+# Create folder for local extensions sources
+RUN mkdir -p ${SRC_EXTENSIONS_DIR}
 
 CMD ["/srv/app/start_ckan_development.sh"]
 
+## When a non-root user is used for Dev the following code will be needed and the above code will be removed
+
+#FROM base AS dev
+
+#ENV SRC_EXTENSIONS_DIR=${APP_DIR}/src_extensions
+
+#USER root
+
+# Install CKAN dev requirements
+#RUN cd ${SRC_DIR}/ckan && \ 
+#pip3 install -r https://raw.githubusercontent.com/ckan/ckan/${CKAN_REF}/dev-requirements.txt
+
+#COPY --chown=ckan-sys:ckan-sys setup/unsafe.cert setup/unsafe.key setup/start_ckan_development.sh setup/install_src.sh ${APP_DIR}
+
+# Update local directories
+#RUN mkdir -p ${SRC_EXTENSIONS_DIR} /var/lib/ckan && \
+#    chown -R ckan-sys:ckan-sys ${SRC_EXTENSIONS_DIR} && \
+#    chown -R ckan:ckan-sys /var/lib/ckan/ && \
+#    chmod 775 ${SRC_EXTENSIONS_DIR}
+
+#USER ckan
+
+#CMD ["/srv/app/start_ckan_development.sh"]
 
 # ──────────────────────────────────────────────────────────────
-
 
 FROM ${ENV} AS final


### PR DESCRIPTION
Fixes: https://github.com/ckan/ckan-docker-base/issues/86

The merge of [PR #80](https://github.com/ckan/ckan-docker-base/pull/80) introduced issues with GitHub Actions workflows that rely on the Dev images. GitHub Actions uses a github user to execute commands inside Docker containers. This user typically has a UID/GID of 1001, but it may vary depending on the container configuration.

With the updated CKAN images now running as a non-root user (ckan/ckan-sys with UID/GID 503/502), permission issues can arise during GitHub Actions workflows.

As a temporary workaround, workflows can include an option to run the CKAN container as the root user.

This PR modifies the Dev images to default to running as the root user while preserving the ability to run as a non-root user when needed.