### PR TITLE
Simplify repo: updates

### DIFF
--- a/ckan-2.11/Dockerfile
+++ b/ckan-2.11/Dockerfile
@@ -83,11 +83,6 @@ RUN groupadd -g 502 ckan-sys && \
     useradd -rm -d /srv/app -s /bin/bash -g ckan-sys -u 502 ckan-sys && \
     useradd -rm -d /srv/app -s /bin/bash -g ckan-sys -u 503 ckan
 
-# Set the ownership of the app directory, usr/local and the entrypoint directory to the ckan-sys user
-RUN chown -R ckan-sys:ckan-sys ${APP_DIR} && \
-    chown -R ckan-sys:ckan-sys /docker-entrypoint.d && \
-    chown -R ckan-sys:ckan-sys /usr/local
-
 COPY setup/prerun.py ${APP_DIR}
 COPY setup/start_ckan.sh ${APP_DIR}
 ADD https://raw.githubusercontent.com/ckan/ckan/${CKAN_REF}/wsgi.py ${APP_DIR}

--- a/ckan-2.9/setup/install_src.sh
+++ b/ckan-2.9/setup/install_src.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+if [ $(id -u) -ne 0 ]; then
+    echo "Please run as root"
+    exit 1
+fi
+
+# Install any local extensions in the src_extensions volume
+echo "Looking for local extensions to install..."
+echo "Extension dir contents:"
+ls -la $SRC_EXTENSIONS_DIR
+for i in $SRC_EXTENSIONS_DIR/*
+do
+    if [ -d $i ];
+    then
+        if [ -d $SRC_DIR/$(basename $i) ];
+        then
+            pip uninstall -y "$(basename $i)"
+        fi
+
+        if [ -f $i/pip-requirements.txt ];
+        then
+            pip install -r $i/pip-requirements.txt
+            echo "Found requirements file in $i"
+        fi
+        if [ -f $i/requirements.txt ];
+        then
+            pip install -r $i/requirements.txt
+            echo "Found requirements file in $i"
+        fi
+        if [ -f $i/dev-requirements.txt ];
+        then
+            pip install -r $i/dev-requirements.txt
+            echo "Found dev-requirements file in $i"
+        fi
+        if [ -f $i/setup.py ];
+        then
+            cd $i
+            python3 $i/setup.py develop
+            echo "Found setup.py file in $i"
+            cd $APP_DIR
+        fi
+        if [ -f $i/pyproject.toml ];
+        then
+            cd $i
+            pip install -e .
+            echo "Found pyproject.toml file in $i"
+            cd $APP_DIR
+        fi
+
+        # Point `use` in test.ini to location of `test-core.ini`
+        if [ -f $i/test.ini ];
+        then
+            echo "Updating \`test.ini\` reference to \`test-core.ini\` for plugin $i"
+            ckan config-tool $i/test.ini "use = config:../../src/ckan/test-core.ini"
+        fi
+    fi
+done


### PR DESCRIPTION
A couple of small updates:

- CKAN 2.11 - There is a duplication of lines in the Dockerfile that caused a problem building the images. The offending lines were removed
- CKAN 2.9 - the `install_src.sh` file is missing. I assume that this file is needed for CKAN 2.9