### PR TITLE
Fix supervisor conf file owners

### DIFF
--- a/ckan-2.10/Dockerfile.py3.10
+++ b/ckan-2.10/Dockerfile.py3.10
@@ -69,7 +69,7 @@ RUN apt-get install --no-install-recommends -y \
         supervisor && \
         mkdir /etc/supervisord.d
 
-COPY setup/supervisord.conf /etc
+COPY setup/supervisord.py3.conf /etc/supervisord.conf
 
 # Install uwsgi, the CKAN application, the dependency packages for CKAN plus some confiquration
 RUN pip3 install -U pip && \

--- a/ckan-2.10/setup/supervisord.py3.conf
+++ b/ckan-2.10/setup/supervisord.py3.conf
@@ -1,7 +1,7 @@
 [unix_http_server]
 file = /tmp/supervisor.sock
 chmod = 0777
-chown = nobody:nogroup
+chown = ckan:ckan-sys
 
 [supervisord]
 logfile = /tmp/supervisord.log

--- a/ckan-2.9/Dockerfile.py3.9
+++ b/ckan-2.9/Dockerfile.py3.9
@@ -69,7 +69,7 @@ RUN apt-get install --no-install-recommends -y \
         supervisor && \
         mkdir /etc/supervisord.d
 
-COPY setup/supervisord.conf /etc
+COPY setup/supervisord.py3.conf /etc/supervisord.conf
 
 # Install uwsgi, the CKAN application, the dependency packages for CKAN plus some confiquration
 

--- a/ckan-2.9/setup/supervisord.py3.conf
+++ b/ckan-2.9/setup/supervisord.py3.conf
@@ -1,7 +1,7 @@
 [unix_http_server]
 file = /tmp/supervisor.sock
 chmod = 0777
-chown = nobody:nogroup
+chown = ckan:ckan-sys
 
 [supervisord]
 logfile = /tmp/supervisord.log


### PR DESCRIPTION
Although supervisor has been removed from 2.11 onward, it is still used in the 2.10 and 2.9 images. In #80 the supervisord.conf [was modified](https://github.com/ckan/ckan-docker-base/pull/80/files#diff-a9f3dc77dfb98b40d119163f7a8049572695f238c20380a6c9ca8e43c4a9daf3R4) to run the process as the newly created `ckan-sys` user, but this same conf file is used in the alpine image, where this user does not exist. Conversely, the 2.9 Python image includes the same file as the alpine one, so it doesn't use the new user.

This PR splits the files in two different versions so they use the appropriate user.
