### PR TITLE
Create an additional Docker image tag with the latest git tag

### DIFF
--- a/.github/workflows/reusable-docker-publish.yml
+++ b/.github/workflows/reusable-docker-publish.yml
@@ -36,6 +36,7 @@ jobs:
         run: |
           VERSION_VALUE=$(cat "ckan-${{ inputs.ckan-major-version }}/VERSION.txt")
           PY_VERSION_VALUE=$(cat "ckan-${{ inputs.ckan-major-version }}/PYTHON_VERSION.txt")
+          LATEST_GIT_TAG=$(git describe --tags --abbrev=0)
           CKAN_MAJOR_VERSION=${{ inputs.ckan-major-version }}
           DOCKERFILE_NAME=${{ inputs.docker-file }}
 
@@ -44,24 +45,31 @@ jobs:
               # Master
 
               BASE_TAGS="ckan/ckan-base:${{ inputs.ckan-major-version}},
-                         ckan/ckan-base:${{ inputs.ckan-major-version}}-py$PY_VERSION_VALUE"
+                         ckan/ckan-base:${{ inputs.ckan-major-version}}-py$PY_VERSION_VALUE,
+                         ckan/ckan-base:${{ inputs.ckan-major-version}}-py$PY_VERSION_VALUE-$LATEST_GIT_TAG"
+
               DEV_TAGS="ckan/ckan-dev:${{ inputs.ckan-major-version}},
-                        ckan/ckan-dev:${{ inputs.ckan-major-version}}-py$PY_VERSION_VALUE"
+                        ckan/ckan-dev:${{ inputs.ckan-major-version}}-py$PY_VERSION_VALUE,
+                        ckan/ckan-dev:${{ inputs.ckan-major-version}}-py$PY_VERSION_VALUE-$LATEST_GIT_TAG"
 
           elif [[ "$CKAN_MAJOR_VERSION" == "2.9" || "$CKAN_MAJOR_VERSION" == "2.10" ]]; then
 
               if [[ "$DOCKERFILE_NAME" == "Dockerfile" ]]; then
                   # 2.9 / 2.10 Alpine
                   BASE_TAGS="ckan/ckan-base:${{ inputs.ckan-major-version}},
-                             ckan/ckan-base:$VERSION_VALUE"
+                             ckan/ckan-base:$VERSION_VALUE,
+                             ckan/ckan-base:${{ inputs.ckan-major-version}}-$LATEST_GIT_TAG"
                   DEV_TAGS="ckan/ckan-dev:${{ inputs.ckan-major-version}},
-                            ckan/ckan-dev:$VERSION_VALUE"
+                            ckan/ckan-dev:$VERSION_VALUE,
+                            ckan/ckan-dev:${{ inputs.ckan-major-version}}-$LATEST_GIT_TAG"
               else
                   # 2.9 / 2.10 Python
                   BASE_TAGS="ckan/ckan-base:${{ inputs.ckan-major-version}}-py$PY_VERSION_VALUE,
-                             ckan/ckan-base:$VERSION_VALUE-py$PY_VERSION_VALUE"
+                             ckan/ckan-base:$VERSION_VALUE-py$PY_VERSION_VALUE,
+                             ckan/ckan-base:${{ inputs.ckan-major-version}}-py$PY_VERSION_VALUE-$LATEST_GIT_TAG"
                   DEV_TAGS="ckan/ckan-dev:${{ inputs.ckan-major-version}}-py$PY_VERSION_VALUE,
-                            ckan/ckan-dev:$VERSION_VALUE-py$PY_VERSION_VALUE"
+                            ckan/ckan-dev:$VERSION_VALUE-py$PY_VERSION_VALUE,
+                            ckan/ckan-dev:${{ inputs.ckan-major-version}}-py$PY_VERSION_VALUE-$LATEST_GIT_TAG"
               fi
 
           else
@@ -71,11 +79,14 @@ jobs:
               BASE_TAGS="ckan/ckan-base:${{ inputs.ckan-major-version}},
                          ckan/ckan-base:$VERSION_VALUE,
                          ckan/ckan-base:${{ inputs.ckan-major-version}}-py$PY_VERSION_VALUE,
-                         ckan/ckan-base:$VERSION_VALUE-py$PY_VERSION_VALUE"
+                         ckan/ckan-base:$VERSION_VALUE-py$PY_VERSION_VALUE,
+                         ckan/ckan-base:${{ inputs.ckan-major-version}}-py$PY_VERSION_VALUE-$LATEST_GIT_TAG"
+
               DEV_TAGS="ckan/ckan-dev:${{ inputs.ckan-major-version}},
                          ckan/ckan-dev:$VERSION_VALUE,
                          ckan/ckan-dev:${{ inputs.ckan-major-version}}-py$PY_VERSION_VALUE,
-                         ckan/ckan-dev:$VERSION_VALUE-py$PY_VERSION_VALUE"
+                         ckan/ckan-dev:$VERSION_VALUE-py$PY_VERSION_VALUE,
+                         ckan/ckan-dev:${{ inputs.ckan-major-version}}-py$PY_VERSION_VALUE-$LATEST_GIT_TAG"
           fi
 
           BASE_TAGS=$(echo $BASE_TAGS | sed 's/ //g')


### PR DESCRIPTION
This allows users that really want to pin a specific release of the Docker images to stick with a particular one.
eg for the 2.11 images, in addition to:

ckan/ckan-base:2.11
ckan/ckan-base:2.11.0
ckan/ckan-base:2.11-py3.10
ckan/ckan-base:2.11.0-py3.10

We will publish this one:

ckan/ckan-base:2.11-py3.10-v20241111

(We don't need a ckan/ckan-base:2.11.0-py3.10-v20241111 one because bumping the patch release will mean doing a new Docker release)


