### PR TITLE
Chore: Update Readme and Changelog #96

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,83 @@
 # ckan-docker-base
 
+
+GitHub Releases [Change Log](https://github.com/ckan/ckan-docker-base/releases)
+
+## Release v20241125
+
+### Important Changes
+There are two important changes to be aware of that relate to the CKAN extensions test workflows using GitHub Actions.
+
+As announced in previous releases the CKAN images are now built using the Debian-based official Python images. The Alpine-based 2.9 and 2.10 images are no longer supported and won't receive updates going forward. These images are the ones most commonly used in tests. In order to use the supported images, change the following section in your .github/workflows/test.yml file:
+```
+    runs-on: ubuntu-latest
+    container:
+      image: ckan/ckan-dev:2.10
+```
+To one of the supported images, e.g.:
+```
+    runs-on: ubuntu-latest
+    container:
+      image: ckan/ckan-dev:2.10-py3.10
+```
+If you are using the matrix property to support multiple CKAN versions, you can use this syntax:
+```
+    strategy:
+      matrix:
+        include:
+          - ckan-version: "2.11"
+            ckan-image: "ckan/ckan-dev:2.11-py3.10"
+          - ckan-version: "2.10"
+            ckan-image: "ckan/ckan-dev:2.10-py3.10"
+          - ckan-version: "2.9"
+            ckan-image: "ckan/ckan-dev:2.9-py3.9"
+      fail-fast: false
+
+    name: CKAN ${{ matrix.ckan-version }}
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.ckan-image }}
+    services:
+      solr:
+        image: ckan/ckan-solr:${{ matrix.ckan-version }}-solr9
+      postgres:
+        image: ckan/ckan-postgres-dev:${{ matrix.ckan-version }}
+```
+To strengthen the images security and follow good practices, the latest version of the images runs with a dedicated user rather than root. This is not supported in GitHub Actions so in order to avoid failures, users will need to add the following option:
+
+```
+    container:
+      image: ckan/ckan-dev:2.11
+      options: --user root
+```
+This commit includes both changes to the workflow file.
+
+Changes in file/directory ownership also means that there is now a separate command to install locally mounted extensions when using the Docker Compose development setup:
+
+```
+docker compose -f docker-compose.dev.yml run -u root ckan-dev ./install_src.sh
+```
+### What's Changed
+* Dev mode: install src dir with separate script by @wardi in [#84](https://github.com/ckan/ckan-docker-base/pull/84)
+* Minimise all root-owned files/directories in the running CKAN container by @kowh-ai in [#80](https://github.com/ckan/ckan-docker-base/pull/80)
+* Simplify repo by @amercader in [#85](https://github.com/ckan/ckan-docker-base/pull/92)
+* Simplify repo: updates by @kowh-ai in [#90](https://github.com/ckan/ckan-docker-base/pull/90)
+* Build and test actions by @amercader in [#89](https://github.com/ckan/ckan-docker-base/pull/89)
+* Add actions to build and push images to Docker Hub by @amercader in [#73](https://github.com/ckan/ckan-docker-base/pull/73)
+* Create an additional Docker image tag with the latest git tag by @amercader in [#92](https://github.com/ckan/ckan-docker-base/pull/92)
+* Full Changelog: [v20241111...v20241125](https://github.com/ckan/ckan-docker-base/compare/v20241111...v20241125)
+
+## Release v20241111
+
+### What's Changed
+* Updates to CKAN 2.11 and master images (remove supervisor and tidy up) by @kowh-ai in [#77](https://github.com/ckan/ckan-docker-base/pull/77)
+* Consolidate use of CKAN_VERSION vs CKAN_TAG ([7f88928](https://github.com/ckan/ckan-docker-base/commit/7f88928d78d51c801e92c20f36105d20a761dd75))
+* Update versions for 2.10.5 and 2.11.0 release ([8ea8056](https://github.com/ckan/ckan-docker-base/commit/8ea8056ea833c7ef34d7f25c979571fd87d9ab4a)])
+* Remove gevent system packages ([ffa9b2a](https://github.com/ckan/ckan-docker-base/commit/ffa9b2a09f2a406bf38ca8afa2303bd04a51f8be))
+* Update and pin ckanext-envvars ([dea7460](https://github.com/ckan/ckan-docker-base/commit/dea74608624495360ff8fdcb9593bd62cf99ad96))
+* Quote ENV vars in 2.9 Dockerfile ([b0a27df](https://github.com/ckan/ckan-docker-base/commit/b0a27dfe94a7b7c33180706e6ab542ede86f520e))
+* Full Changelog: [v20240701...v20241111](https://github.com/ckan/ckan-docker-base/compare/v20240701...v20241111)
+
 ## Release 20240701
 
 * Going forward, the CKAN Docker images will use Debian-based [official Python images](https://hub.docker.com/_/python)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Pre-configured CKAN Docker images
 
-This is the Git repo of the official Docker images for [CKAN](https://github.com/ckan/ckan/).
+This is the Git repo of the official [Docker images](https://github.com/ckan/ckan-docker-base) for [CKAN](https://github.com/ckan/ckan/).
+
+Please raise issues or code contributions at [github:ckan/ckan-docker-base](https://github.com/ckan/ckan-docker-base)
 
 The images will usually be used as a Docker Compose install in conjunction with other Docker images that make up the CKAN platform. The official CKAN Docker install is located here: [ckan-docker](https://github.com/ckan/ckan-docker)
 


### PR DESCRIPTION
* Updated Readme to back link to this repo for docker hub info page.
* Update Change Log to fill in the missing version releases (Based off GitHub Releases page)