### PR TITLE
Fetch tags in git checkout to fix publish workflows

### DIFF
--- a/.github/workflows/reusable-docker-publish.yml
+++ b/.github/workflows/reusable-docker-publish.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-tags: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
Introduced in #92 
GitHub Actions performs a shallow clone that doesn't include all tags by default so this command:

    LATEST_GIT_TAG=$(git describe --tags --abbrev=0)

Was failing with:

     fatal: No names found, cannot describe anything.

This setting makes the checkout fetch the tags as well