### PR TITLE
Fetch tags manually in publish workflow

### DIFF
--- a/.github/workflows/reusable-docker-publish.yml
+++ b/.github/workflows/reusable-docker-publish.yml
@@ -22,8 +22,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-tags: true
+
+      - name: Fetch tags 
+        # Needed because of actions/checkout#1467
+        run: |
+          git fetch --tags --force
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
`fetch-tags: true` in the checkout action does not work as expected and causes an error:

    Error: fatal: Cannot fetch both 2704e6e918d2c70a4f44348e34618ef5146211b4
    and refs/tags/v20241203 to refs/tags/v20241203

The issue is described in
https://github.com/actions/checkout/issues/1467

We will just fetch the tags manually