### PR TITLE
move debugpy install to install_src, writable home for dev

### DIFF
--- a/ckan-2.10/setup/install_src.sh
+++ b/ckan-2.10/setup/install_src.sh
@@ -5,6 +5,10 @@ if [ $(id -u) -ne 0 ]; then
     exit 1
 fi
 
+if [ "$USE_DEBUGPY_FOR_DEV" = true ] ; then
+    pip install debugpy
+fi
+
 # Install any local extensions in the src_extensions volume
 echo "Looking for local extensions to install..."
 echo "Extension dir contents:"

--- a/ckan-2.10/setup/start_ckan_development.sh
+++ b/ckan-2.10/setup/start_ckan_development.sh
@@ -51,11 +51,10 @@ then
     done
 fi
 
-CKAN_RUN="ckan -c $CKAN_INI run -H 0.0.0.0"
+CKAN_RUN="/usr/local/bin/ckan -c $CKAN_INI run -H 0.0.0.0"
 CKAN_OPTIONS=""
 if [ "$USE_DEBUGPY_FOR_DEV" = true ] ; then
-    pip install debugpy
-    CKAN_RUN="/usr/bin/python -m debugpy --listen 0.0.0.0:5678 $CKAN_RUN"
+    CKAN_RUN="/usr/local/bin/python -m debugpy --listen 0.0.0.0:5678 $CKAN_RUN"
     CKAN_OPTIONS="$CKAN_OPTIONS --disable-reloader"
 fi
 

--- a/ckan-2.11/Dockerfile
+++ b/ckan-2.11/Dockerfile
@@ -129,10 +129,11 @@ pip3 install -r https://raw.githubusercontent.com/ckan/ckan/${CKAN_REF}/dev-requ
 
 COPY --chown=ckan-sys:ckan-sys setup/unsafe.cert setup/unsafe.key setup/start_ckan_development.sh setup/install_src.sh ${APP_DIR}
 
-# Update local directories
+# Update local directories, /srv/app as writable home dir
 RUN mkdir -p ${SRC_EXTENSIONS_DIR} /var/lib/ckan && \
     chown -R ckan-sys:ckan-sys ${SRC_EXTENSIONS_DIR} && \
     chown -R ckan:ckan-sys /var/lib/ckan/ && \
+    chown ckan:ckan-sys /srv/app/ && \
     chmod 775 ${SRC_EXTENSIONS_DIR}
 
 USER ckan

--- a/ckan-2.11/setup/install_src.sh
+++ b/ckan-2.11/setup/install_src.sh
@@ -5,6 +5,10 @@ if [ $(id -u) -ne 0 ]; then
     exit 1
 fi
 
+if [ "$USE_DEBUGPY_FOR_DEV" = true ] ; then
+    pip install debugpy
+fi
+
 # Install any local extensions in the src_extensions volume
 echo "Looking for local extensions to install..."
 echo "Extension dir contents:"

--- a/ckan-2.11/setup/start_ckan_development.sh
+++ b/ckan-2.11/setup/start_ckan_development.sh
@@ -51,11 +51,10 @@ then
     done
 fi
 
-CKAN_RUN="ckan -c $CKAN_INI run -H 0.0.0.0"
+CKAN_RUN="/usr/local/bin/ckan -c $CKAN_INI run -H 0.0.0.0"
 CKAN_OPTIONS=""
 if [ "$USE_DEBUGPY_FOR_DEV" = true ] ; then
-    pip install debugpy
-    CKAN_RUN="/usr/bin/python -m debugpy --listen 0.0.0.0:5678 $CKAN_RUN"
+    CKAN_RUN="/usr/local/bin/python -m debugpy --listen 0.0.0.0:5678 $CKAN_RUN"
     CKAN_OPTIONS="$CKAN_OPTIONS --disable-reloader"
 fi
 

--- a/ckan-2.9/setup/install_src.sh
+++ b/ckan-2.9/setup/install_src.sh
@@ -5,6 +5,10 @@ if [ $(id -u) -ne 0 ]; then
     exit 1
 fi
 
+if [ "$USE_DEBUGPY_FOR_DEV" = true ] ; then
+    pip install debugpy
+fi
+
 # Install any local extensions in the src_extensions volume
 echo "Looking for local extensions to install..."
 echo "Extension dir contents:"

--- a/ckan-2.9/setup/start_ckan_development.sh
+++ b/ckan-2.9/setup/start_ckan_development.sh
@@ -102,11 +102,10 @@ then
     done
 fi
 
-CKAN_RUN="ckan -c $CKAN_INI run -H 0.0.0.0"
+CKAN_RUN="/usr/local/bin/ckan -c $CKAN_INI run -H 0.0.0.0"
 CKAN_OPTIONS=""
 if [ "$USE_DEBUGPY_FOR_DEV" = true ] ; then
-    pip install debugpy
-    CKAN_RUN="/usr/bin/python -m debugpy --listen 0.0.0.0:5678 $CKAN_RUN"
+    CKAN_RUN="/usr/local/bin/python -m debugpy --listen 0.0.0.0:5678 $CKAN_RUN"
     CKAN_OPTIONS="$CKAN_OPTIONS --disable-reloader"
 fi
 


### PR DESCRIPTION
debugpy needs to be installed from the install script, and the `ckan` home directory `/srv/app` needs to be writable to install vscode inside the container (also useful for files like .bash_history when developing)