### PR TITLE
chore: enable linux/arm64 containers

### DIFF
--- a/.github/workflows/reusable-build-and-test.yml
+++ b/.github/workflows/reusable-build-and-test.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Build base image
         uses: docker/build-push-action@v6
         with:
+          platforms: linux/amd64,linux/arm64
           push: false
           load: true
           context: "{{defaultContext}}:ckan-${{ inputs.ckan-major-version }}"
@@ -85,6 +86,7 @@ jobs:
       - name: Build dev image
         uses: docker/build-push-action@v6
         with:
+          platforms: linux/amd64,linux/arm64
           push: false
           load: true
           context: "{{defaultContext}}:ckan-${{ inputs.ckan-major-version }}"

--- a/.github/workflows/reusable-docker-publish.yml
+++ b/.github/workflows/reusable-docker-publish.yml
@@ -111,6 +111,7 @@ jobs:
       - name: Build ${{ inputs.ckan-major-version }} base
         uses: docker/build-push-action@v6
         with:
+          platforms: linux/amd64,linux/arm64
           push: true
           context: "{{defaultContext}}:ckan-${{ inputs.ckan-major-version }}"
           file: ${{ inputs.docker-file }}
@@ -122,6 +123,7 @@ jobs:
       - name: Build ${{ inputs.ckan-major-version }} dev
         uses: docker/build-push-action@v6
         with:
+          platforms: linux/amd64,linux/arm64
           push: true
           context: "{{defaultContext}}:ckan-${{ inputs.ckan-major-version }}"
           file: ${{ inputs.docker-file }}

--- a/build.sh
+++ b/build.sh
@@ -38,6 +38,7 @@ build_images() {
         DOCKER_BUILDKIT=1 docker build \
             --build-arg="ENV=$env" \
             --build-arg="CKAN_REF=$ckan_tag" \
+            --platform linux/amd64,linux/arm64 \
             -t "$python_tag_name" \
             -t "$python_alt_tag_name" \
             -f "ckan-$ckan_version_ref/$python_dockerfile" \
@@ -48,6 +49,7 @@ build_images() {
     DOCKER_BUILDKIT=1 docker build \
         --build-arg="ENV=$env" \
         --build-arg="CKAN_REF=$ckan_tag" \
+        --platform linux/amd64,linux/arm64 \
          -t "$tag_name" \
          -t "$alt_tag_name" \
          -t "$python_tag_name" \


### PR DESCRIPTION
This change will enable linux/amd64 and linux/arm64 containers to be available.

[act](https://github.com/nektos/act) has gotten quite good to run the github actions locally, sadly with Mac Apple Silicon, the ckan container is not linux/arm64 enabled, the workarounds don't work when you are running containers in containers.

i.e. ``act -W '.github/workflows/test.yml' --container-architecture linux/amd64`` 

https://docs.docker.com/build/ci/github-actions/multi-platform/
https://docs.docker.com/build/building/multi-platform/