### PR TITLE
Add apt install for patch

### DIFF
--- a/ckan-2.10/Dockerfile.py3.10
+++ b/ckan-2.10/Dockerfile.py3.10
@@ -59,6 +59,7 @@ RUN apt-get install --no-install-recommends -y \
         g++ \
         linux-headers-generic \
         libtool \
+        patch \
         wget
 
 # Create the src directory

--- a/ckan-2.11/Dockerfile
+++ b/ckan-2.11/Dockerfile
@@ -59,6 +59,7 @@ RUN apt-get install --no-install-recommends -y \
         g++ \
         linux-headers-generic \
         libtool \
+        patch \
         wget
 
 # Create the src directory


### PR DESCRIPTION
patch is needed to deploy updates at runtime
for ckan/ckan-docker#168