### PR TITLE
Parameterize python version for CKAN 2.11

### DIFF
--- a/.github/workflows/build-and-test-2.11-pyver3.11.yml
+++ b/.github/workflows/build-and-test-2.11-pyver3.11.yml
@@ -1,0 +1,10 @@
+name: Build and test CKAN 2.11 images (python 3.11)
+
+on: push
+
+jobs:
+  call-reusable-workflow:
+    uses: ./.github/workflows/reusable-build-and-test.yml
+    with:
+      ckan-major-version: "2.11"
+      python-version: "3.11"

--- a/.github/workflows/reusable-build-and-test.yml
+++ b/.github/workflows/reusable-build-and-test.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
             PYTHON_VERSION_VALUE=$(cat "ckan-${{ inputs.ckan-major-version }}/PYTHON_VERSION.txt")
             echo "Using ref $PYTHON_VERSION_VALUE in next steps"
-            echo "PYTHON_VERSION=$PYTHON_VERSION_VALUE" >> $GITHUB_ENV
+            echo "PYTHON_REF=$PYTHON_VERSION_VALUE" >> $GITHUB_ENV
 
       - name: Build base image
         uses: docker/build-push-action@v6

--- a/.github/workflows/reusable-build-and-test.yml
+++ b/.github/workflows/reusable-build-and-test.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
             PYTHON_VERSION_VALUE=$(cat "ckan-${{ inputs.ckan-major-version }}/PYTHON_VERSION.txt")
             echo "Using ref $PYTHON_VERSION_VALUE in next steps"
-            echo "PYTHON_REF=$PYTHON_VERSION_VALUE" >> $GITHUB_ENV
+            echo "PYTHON_VERSION=$PYTHON_VERSION_VALUE" >> $GITHUB_ENV
 
       - name: Build base image
         uses: docker/build-push-action@v6
@@ -65,7 +65,7 @@ jobs:
           build-args: |
             CKAN_REF=${{ env.CKAN_REF }}
             ENV=base
-            PYTHON_VERSION=${{ env.PYTHON_REF }}
+            PYTHON_VERSION=${{ env.PYTHON_VERSION }}
           tags: |
             ckan-base-${{ inputs.ckan-major-version }}-local
 
@@ -99,7 +99,7 @@ jobs:
           build-args: |
             CKAN_REF=${{ env.CKAN_REF }}
             ENV=dev
-            PYTHON_VERSION=${{ env.PYTHON_REF }}
+            PYTHON_VERSION=${{ env.PYTHON_VERSION }}
           tags: |
             ckan-dev-${{ inputs.ckan-major-version }}-local
 

--- a/.github/workflows/reusable-build-and-test.yml
+++ b/.github/workflows/reusable-build-and-test.yml
@@ -59,6 +59,7 @@ jobs:
           build-args: |
             CKAN_REF=${{ env.CKAN_REF }}
             ENV=base
+            PYTHON_VERSION=3.10
           tags: |
             ckan-base-${{ inputs.ckan-major-version }}-local
 

--- a/.github/workflows/reusable-build-and-test.yml
+++ b/.github/workflows/reusable-build-and-test.yml
@@ -65,7 +65,7 @@ jobs:
           build-args: |
             CKAN_REF=${{ env.CKAN_REF }}
             ENV=base
-            PYTHON_VERSION=${{ env.PYTHON_VERSION }}
+            PYTHON_VERSION=${{ env.PYTHON_REF }}
           tags: |
             ckan-base-${{ inputs.ckan-major-version }}-local
 
@@ -99,7 +99,7 @@ jobs:
           build-args: |
             CKAN_REF=${{ env.CKAN_REF }}
             ENV=dev
-            PYTHON_VERSION=${{ env.PYTHON_VERSION }}
+            PYTHON_VERSION=${{ env.PYTHON_REF }}
           tags: |
             ckan-dev-${{ inputs.ckan-major-version }}-local
 

--- a/.github/workflows/reusable-build-and-test.yml
+++ b/.github/workflows/reusable-build-and-test.yml
@@ -93,6 +93,7 @@ jobs:
           build-args: |
             CKAN_REF=${{ env.CKAN_REF }}
             ENV=dev
+            PYTHON_VERSION=3.10
           tags: |
             ckan-dev-${{ inputs.ckan-major-version }}-local
 

--- a/.github/workflows/reusable-build-and-test.yml
+++ b/.github/workflows/reusable-build-and-test.yml
@@ -49,6 +49,12 @@ jobs:
           echo "Using ref $VERSION_VALUE in next steps"
           echo "CKAN_REF=$VERSION_VALUE" >> $GITHUB_ENV
 
+      - name: Read python version from VERSION file
+        run: |
+            PYTHON_VERSION_VALUE=$(cat "ckan-${{ inputs.ckan-major-version }}/PYTHON_VERSION.txt")
+            echo "Using ref $PYTHON_VERSION_VALUE in next steps"
+            echo "PYTHON_REF=$PYTHON_VERSION_VALUE" >> $GITHUB_ENV
+
       - name: Build base image
         uses: docker/build-push-action@v6
         with:
@@ -59,7 +65,7 @@ jobs:
           build-args: |
             CKAN_REF=${{ env.CKAN_REF }}
             ENV=base
-            PYTHON_VERSION=3.10
+            PYTHON_VERSION=${{ env.PYTHON_REF }}
           tags: |
             ckan-base-${{ inputs.ckan-major-version }}-local
 
@@ -93,7 +99,7 @@ jobs:
           build-args: |
             CKAN_REF=${{ env.CKAN_REF }}
             ENV=dev
-            PYTHON_VERSION=3.10
+            PYTHON_VERSION=${{ env.PYTHON_REF }}
           tags: |
             ckan-dev-${{ inputs.ckan-major-version }}-local
 

--- a/.github/workflows/reusable-build-and-test.yml
+++ b/.github/workflows/reusable-build-and-test.yml
@@ -10,6 +10,10 @@ on:
         required: false
         default: 'Dockerfile'
         type: string
+      python-version:
+        required: false
+        default: ''
+        type: string
 
 jobs:
   build_and_test:
@@ -54,6 +58,12 @@ jobs:
             PYTHON_VERSION_VALUE=$(cat "ckan-${{ inputs.ckan-major-version }}/PYTHON_VERSION.txt")
             echo "Using ref $PYTHON_VERSION_VALUE in next steps"
             echo "PYTHON_REF=$PYTHON_VERSION_VALUE" >> $GITHUB_ENV
+
+      - name: Override Python version if input is provided
+        if: inputs.python-version != ''
+        run: |
+            echo "Overriding Python version with user input: ${{ inputs.python-version }}"
+            echo "PYTHON_REF=${{ inputs.python-version }}" >> $GITHUB_ENV
 
       - name: Build base image
         uses: docker/build-push-action@v6

--- a/README.md
+++ b/README.md
@@ -75,10 +75,11 @@ All operations are done using the `build.sh` script located at the root of the r
 ```
 Usage: ./build.sh <action> [<params>]
 Available actions:
-  versions                   - Shows the current CKAN versions used
-  build <version> [base|dev] - Builds images for a CKAN version
-                               Pass 'base' or 'dev' to just build these.
-  push  <version>            - Pushes images to the Docker Hub
+  versions                                - Shows the current CKAN versions used
+  build <version> [base|dev] [py version] - Builds images for a CKAN version
+                                          - Pass 'base' or 'dev' to just build these.
+                                          - Optionally specify a Python version.
+  push  <version>                         - Pushes images to the Docker Hub
 
 ```
 
@@ -88,8 +89,13 @@ For instance:
 ./build.sh build 2.11
 
 ./build.sh build master
+./build.sh build 2.11
 ./build.sh build 2.10 base
 ./build.sh build 2.9 dev
+./build.sh build 2.11 3.11
+./build.sh build 2.9 3.10
+./build.sh build 2.11 base 3.11
+./build.sh build 2.10 dev 3.10
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Available actions:
   push  <version>                         - Pushes images to the Docker Hub
 
 ```
+In the absence of a specified Python version, the version defined in PYTHON_VERSION.txt 
+will be used as the default
 
 For instance:
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ For instance:
 
 ```
 ./build.sh build 2.11
-
 ./build.sh build master
 ./build.sh build 2.11
 ./build.sh build 2.10 base
@@ -100,4 +99,14 @@ For instance:
 ./build.sh build 2.10 dev 3.10
 ```
 
+### Building the images directly
 
+Of course the images can be built directly
+
+For instance:
+
+```
+docker build --build-arg ENV=base --build-arg CKAN_REF=ckan-2.11.2 --build-arg PYTHON_VERSION=3.11
+docker build --build-arg ENV=dev --build-arg CKAN_REF=ckan-2.10.7 --build-arg PYTHON_VERSION=3.10
+docker build --build-arg ENV=base --build-arg CKAN_REF=master --build-arg PYTHON_VERSION=3.11
+```

--- a/README.md
+++ b/README.md
@@ -106,7 +106,9 @@ Of course the images can be built directly
 For instance:
 
 ```
-docker build --build-arg ENV=base --build-arg CKAN_REF=ckan-2.11.2 --build-arg PYTHON_VERSION=3.11
-docker build --build-arg ENV=dev --build-arg CKAN_REF=ckan-2.10.7 --build-arg PYTHON_VERSION=3.10
-docker build --build-arg ENV=base --build-arg CKAN_REF=master --build-arg PYTHON_VERSION=3.11
+docker build --build-arg=ENV=base --build-arg=CKAN_REF=ckan-2.11.2 --build-arg=PYTHON_VERSION=3.11 -t ckan/ckan-base:2.11.2 -t ckan/ckan-base:2.11 -t ckan/ckan-base:2.11.2-py3.11 -t ckan/ckan-base:2.11-py3.11 ckan-2.11
+
+docker build --build-arg=ENV=base --build-arg=CKAN_REF=master --build-arg=PYTHON_VERSION=3.10 -t ckan/ckan-base:master -t ckan/ckan-base:master -t ckan/ckan-base:master-py3.10 -t ckan/ckan-base:master-py3.10 ckan-master
+
+docker build --build-arg=ENV=dev --build-arg=CKAN_REF=ckan-2.9.11 -t ckan/ckan-dev:2.9.11-py3.9 -t ckan/ckan-dev:2.9-py3.9 -f ckan-2.9/Dockerfile.py3.9 ckan-2.9
 ```

--- a/build.sh
+++ b/build.sh
@@ -48,6 +48,7 @@ build_images() {
     DOCKER_BUILDKIT=1 docker build \
         --build-arg="ENV=$env" \
         --build-arg="CKAN_REF=$ckan_tag" \
+        --build-arg="PYTHON_VERSION=$python_version" \
          -t "$tag_name" \
          -t "$alt_tag_name" \
          -t "$python_tag_name" \

--- a/build.sh
+++ b/build.sh
@@ -2,16 +2,21 @@
 
 set -e
 
-
 set_vars() {
     local ckan_version_ref="$1"
     local env="$2"
+    local python_version="$3"
 
     ckan_version=$(cat "ckan-$ckan_version_ref/VERSION.txt")
-    python_version=$(cat "ckan-$ckan_version_ref/PYTHON_VERSION.txt")
-    python_dockerfile=Dockerfile.py$python_version
+    if [ -z "$python_version" ]; then
+        PYTHON_VERSION=$(cat "ckan-$ckan_version_ref/PYTHON_VERSION.txt")
+    else
+        PYTHON_VERSION="$python_version"
+    fi
+
+    python_dockerfile=Dockerfile.py$PYTHON_VERSION
     tag_name="ckan/ckan-$env:$ckan_version"
-    python_tag_name="ckan/ckan-$env:$ckan_version-py$python_version"
+    python_tag_name="ckan/ckan-$env:$ckan_version-py$PYTHON_VERSION"
     if [[ "$ckan_version" == "master" || "$ckan_version" == dev* ]]; then
         ckan_tag=$ckan_version
         alt_tag_name=$tag_name
@@ -21,17 +26,16 @@ set_vars() {
         ckan_version_major=$(echo "$ckan_version" | cut -d'.' -f1)
         ckan_version_minor=$(echo "$ckan_version" | cut -d'.' -f2)
         alt_tag_name="ckan/ckan-$env:$ckan_version_major.$ckan_version_minor"
-        python_alt_tag_name="ckan/ckan-$env:$ckan_version_major.$ckan_version_minor-py$python_version"
+        python_alt_tag_name="ckan/ckan-$env:$ckan_version_major.$ckan_version_minor-py$PYTHON_VERSION"
     fi
-
 }
-
 
 build_images() {
     local ckan_version_ref="$1"
     local env="$2"
+    local python_version="$3"
 
-    set_vars "$ckan_version_ref" "$env"
+    set_vars "$ckan_version_ref" "$env" "$python_version"
 
     if [ -f "ckan-$ckan_version_ref/$python_dockerfile" ]; then
         # Build Python image if there's a separate .pyXX Dockerfile
@@ -44,65 +48,30 @@ build_images() {
             "ckan-$ckan_version_ref"
     fi
 
-    # Build image 
+    # Build the main CKAN image
     DOCKER_BUILDKIT=1 docker build \
         --build-arg="ENV=$env" \
         --build-arg="CKAN_REF=$ckan_tag" \
-        --build-arg="PYTHON_VERSION=$python_version" \
-         -t "$tag_name" \
-         -t "$alt_tag_name" \
-         -t "$python_tag_name" \
-         -t "$python_alt_tag_name" \
-         "ckan-$ckan_version_ref"
+        --build-arg="PYTHON_VERSION=$PYTHON_VERSION" \
+        -t "$tag_name" \
+        -t "$alt_tag_name" \
+        -t "$python_tag_name" \
+        -t "$python_alt_tag_name" \
+        "ckan-$ckan_version_ref"
 }
-
-
-push_images() {
-    local ckan_version_ref="$1"
-    local env="$2"
-
-    set_vars "$ckan_version_ref" "$env"
-    
-    echo "Pushing $tag_name"
-    docker push "$tag_name"
-    echo "Pushing $alt_tag_name"
-    docker push "$alt_tag_name"
-    echo "Pushing $python_tag_name"
-    docker push "$python_tag_name"
-    echo "Pushing $python_alt_tag_name"
-    docker push "$python_alt_tag_name"
-
-}
-
-
-show_versions() {
-    echo "Versions built currently:"
-    cat ckan-*/VERSION.txt | sort -t. -k1,1n -k2,2n | sed 's/^/* /'
-}
-
 
 show_usage() {
     echo "Usage: $0 <action> [<params>]"
     echo "Available actions:"
-    echo "  versions                   - Shows the current CKAN versions used"
-    echo "  build <version> [base|dev] - Builds images for a CKAN version"
-    echo "                               Pass 'base' or 'dev' to just build these."
-    echo "  push  <version>            - Pushes images to the Docker Hub"
+    echo "  versions                                - Shows the current CKAN versions used"
+    echo "  build <version> [base|dev] [py version] - Builds images for a CKAN version"
+    echo "                                            Optionally specify 'base' or 'dev'."
+    echo "                                            Optionally specify a Python version."
+    echo "  push  <version>                         - Pushes images to the Docker Hub"
     exit 1
 }
 
-check_push_msg="
-**********************************************************************
-*                                                                    *
-* Warning: Pushing images to the Docker Hub should generally be done *
-* via automated GitHub Actions.                                      *
-*                                                                    *
-**********************************************************************
-
-Are you sure you want to proceed? [y/N]"
-
-
-# Check if at least one parameter is provided
+# Main script logic
 if [ $# -eq 0 ]; then
     show_usage
 fi
@@ -111,7 +80,7 @@ action=$1
 
 case "$action" in
     "versions")
-           show_versions 
+        show_versions
         ;;
     "build")
         ckan_version_ref=$2
@@ -127,34 +96,57 @@ case "$action" in
             exit 1
         fi
 
-        base_or_dev=$3
+        # Shift to handle optional arguments more flexibly
+        shift 2
 
-        case "$base_or_dev" in
-            "base")
-                build_base=true
-                ;;
-            "dev")
-                build_dev=true
-                ;;
-            "")
-                build_base=true
-                build_dev=true
-                ;;
-            *)
-                echo "Please enter 'base' or 'dev'"
-                show_usage
-                exit 1
-        esac
+        base_or_dev=""
+        python_version=""
 
-        if [ "$build_base" = true ]; then
-            build_images "$ckan_version_ref" "base"
+        # Process remaining arguments
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                "base"|"dev")
+                    base_or_dev="$1"
+                    ;;
+                *)
+                    # Assume it's a Python version
+                    python_version="$1"
+                    ;;
+            esac
+            shift
+        done
+
+        # Determine which images to build
+        if [ -z "$base_or_dev" ]; then
+            build_base=true
+            build_dev=true
+        else
+            case "$base_or_dev" in
+                "base")
+                    build_base=true
+                    ;;
+                "dev")
+                    build_dev=true
+                    ;;
+                *)
+                    echo "Invalid option: $base_or_dev. Use 'base' or 'dev'."
+                    show_usage
+                    exit 1
+                    ;;
+            esac
         fi
+
+        # Build base image if requested
+        if [ "$build_base" = true ]; then
+            build_images "$ckan_version_ref" "base" "$python_version"
+        fi
+
+        # Build dev image if requested
         if [ "$build_dev" = true ]; then
-            build_images "$ckan_version_ref" "dev"
+            build_images "$ckan_version_ref" "dev" "$python_version"
         fi
         ;;
     "push")
-
         ckan_version_ref=$2
 
         read -p "$check_push_msg" -n 1 -r answer

--- a/ckan-2.11/Dockerfile
+++ b/ckan-2.11/Dockerfile
@@ -1,6 +1,7 @@
 ARG ENV=base
+ARG PYTHON_VERSION
 
-FROM python:3.10-slim-bookworm AS python
+FROM python:${PYTHON_VERSION}-slim-bookworm AS python
 
 
 # ┌─────────────────────────────────────────────────────────────┐


### PR DESCRIPTION
The Python version is specified here: [PYTHON_VERSION](https://github.com/ckan/ckan-docker-base/blob/main/ckan-2.11/PYTHON_VERSION.txt) When a new version of Python is required to build the base/dev images for CKAN 2.11 (and subsequent future versions...`2.12` etc) the new version (value) can be changed there and new images built based on that version of Python.

I have intentionally left out CKAN `2.10` and `2.9` as this would be messy as those versions have specific Dockerfiles based on the `python:<version>-slim-bookworm` base images 