### PR TITLE
DataPusher explicitly installs wget

### DIFF
--- a/datapusher/Dockerfile
+++ b/datapusher/Dockerfile
@@ -34,7 +34,8 @@ RUN apk add --no-cache \
     libxml2-dev \
     libxslt-dev \
     openssl-dev \
-    cargo
+    cargo \
+    wget
 
 RUN mkdir -p ${APP_DIR}/src && cd ${APP_DIR}/src && \
     git clone -b ${DATAPUSHER_VERSION} --depth=1 --single-branch ${GIT_URL} && \


### PR DESCRIPTION
fixes: https://github.com/ckan/ckan-docker-base/issues/109

Explicitly installs `wget` system package as the alpine (preinstalled) wget command software does not seem to work correctly if DataPusher is running behind a proxy

NB: This will update the `ckan/ckan-base-datapusher:0.0.21` image so an accompanying ckan-docker repo PR should also be created as it currently uses `ckan/ckan-base-datapusher:0.0.20`