### PR TITLE
Overwrite UWSGI_OPTS from ENV or adapt with EXTRA_UWSGI_OPTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ ckan-X.XX
 
 ```
 
+`start_ckan.sh` contains environment variables to configure the behavior of the [uWSGI](https://uwsgi-docs.readthedocs.io/en/latest/) server that runs CKAN.
+See [here](https://github.com/ckan/ckan-docker#uwsgi-command-line-arguments) to find the documentation of the available options.
+
 ### Release
 
 Images are built and pushed to the Docker Hub after a new [release](https://github.com/ckan/ckan-docker-base/releases)
@@ -82,7 +85,7 @@ Available actions:
   push  <version>                         - Pushes images to the Docker Hub
 
 ```
-In the absence of a specified Python version, the version defined in PYTHON_VERSION.txt 
+In the absence of a specified Python version, the version defined in PYTHON_VERSION.txt
 will be used as the default
 
 For instance:

--- a/ckan-2.10/setup/start_ckan.sh
+++ b/ckan-2.10/setup/start_ckan.sh
@@ -33,14 +33,24 @@ then
     done
 fi
 
-UWSGI_OPTS="--socket /tmp/uwsgi.sock \
-            --wsgi-file /srv/app/wsgi.py \
-            --module wsgi:application \
-            --http [::]:5000 \
-            --master --enable-threads \
-            --lazy-apps \
-            -p 2 -L -b 32768 --vacuum \
-            --harakiri $UWSGI_HARAKIRI"
+# Define default UWSGI options
+DEFAULT_UWSGI_OPTS="--socket /tmp/uwsgi.sock \
+                    --wsgi-file /srv/app/wsgi.py \
+                    --module wsgi:application \
+                    --http [::]:5000 \
+                    --master --enable-threads \
+                    --lazy-apps \
+                    -p 2 -L -b 32768 --vacuum \
+                    --harakiri ${UWSGI_HARAKIRI:-60}"
+
+# Use UWSGI_OPTS from environment if set, otherwise use defaults
+UWSGI_OPTS="${UWSGI_OPTS:-$DEFAULT_UWSGI_OPTS}"
+
+# Append EXTRA_UWSGI_OPTS if set
+if [ -n "$EXTRA_UWSGI_OPTS" ]
+then
+  UWSGI_OPTS="$UWSGI_OPTS $EXTRA_UWSGI_OPTS"
+fi
 
 if [ $? -eq 0 ]
 then

--- a/ckan-2.11/setup/start_ckan.sh
+++ b/ckan-2.11/setup/start_ckan.sh
@@ -33,14 +33,24 @@ then
     done
 fi
 
-UWSGI_OPTS="--socket /tmp/uwsgi.sock \
-            --wsgi-file /srv/app/wsgi.py \
-            --module wsgi:application \
-            --http [::]:5000 \
-            --master --enable-threads \
-            --lazy-apps \
-            -p 2 -L -b 32768 --vacuum \
-            --harakiri $UWSGI_HARAKIRI"
+# Define default UWSGI options
+DEFAULT_UWSGI_OPTS="--socket /tmp/uwsgi.sock \
+                    --wsgi-file /srv/app/wsgi.py \
+                    --module wsgi:application \
+                    --http [::]:5000 \
+                    --master --enable-threads \
+                    --lazy-apps \
+                    -p 2 -L -b 32768 --vacuum \
+                    --harakiri ${UWSGI_HARAKIRI:-60}"
+
+# Use UWSGI_OPTS from environment if set, otherwise use defaults
+UWSGI_OPTS="${UWSGI_OPTS:-$DEFAULT_UWSGI_OPTS}"
+
+# Append EXTRA_UWSGI_OPTS if set
+if [ -n "$EXTRA_UWSGI_OPTS" ]
+then
+  UWSGI_OPTS="$UWSGI_OPTS $EXTRA_UWSGI_OPTS"
+fi
 
 if [ $? -eq 0 ]
 then

--- a/ckan-2.9/setup/start_ckan.sh
+++ b/ckan-2.9/setup/start_ckan.sh
@@ -27,15 +27,24 @@ then
 fi
 
 # Set the common uwsgi options
-UWSGI_OPTS="--plugins http,python \
-            --socket /tmp/uwsgi.sock \
-            --wsgi-file /srv/app/wsgi.py \
-            --module wsgi:application \
-            --http 0.0.0.0:5000 \
-            --master --enable-threads \
-            --lazy-apps \
-            -p 2 -L -b 32768 --vacuum \
-            --harakiri $UWSGI_HARAKIRI"
+DEFAULT_UWSGI_OPTS="--plugins http,python \
+                    --socket /tmp/uwsgi.sock \
+                    --wsgi-file /srv/app/wsgi.py \
+                    --module wsgi:application \
+                    --http 0.0.0.0:5000 \
+                    --master --enable-threads \
+                    --lazy-apps \
+                    -p 2 -L -b 32768 --vacuum \
+                    --harakiri $UWSGI_HARAKIRI"
+
+# Use UWSGI_OPTS from environment if set, otherwise use defaults
+UWSGI_OPTS="${UWSGI_OPTS:-$DEFAULT_UWSGI_OPTS}"
+
+# Append EXTRA_UWSGI_OPTS if set
+if [ -n "$EXTRA_UWSGI_OPTS" ]
+then
+  UWSGI_OPTS="$UWSGI_OPTS $EXTRA_UWSGI_OPTS"
+fi
 
 if [ $? -eq 0 ]
 then


### PR DESCRIPTION
This PR resolves #114. It extends the bahavior of `start_ckan.sh` to allow both _overwriting_ and _extending_ the `uwsgi` command line args. The current behavior of `UWSGI_OPTS` env var remains untouched, so this won't affect users that already overwirte `UWSGI_OPTS`, or don't.

- In `start_ckan.sh` there is a new env var `DEFAULT_UWSGI_OPTS` that defines default options for `uwsgi`. This contains what was previously stored in `UWSGI_OPTS` in `start_ckan.sh`.
- If `UWSGI_OPTS` is set at runtime, `DEFAULT_UWSGI_OPTS` is overwritten with the content of `UWSGI_OPTS`.
- If the new env var `EXTRA_UWSGI_OPTS` is set at runtime, its content is appended to `UWSG_OPTS`.
- For `UWSGI_HARAKIRI` a default values of 60 is introduced.

If there is any place to document this, let me know, I can add documentation.
Happily awaiting your review. :-)
