### PR TITLE
reusable-docker-publish.yml needs to send the python parameter to build CKAN 2.11

### DIFF
--- a/.github/workflows/reusable-docker-publish.yml
+++ b/.github/workflows/reusable-docker-publish.yml
@@ -117,7 +117,7 @@ jobs:
           build-args: |
             CKAN_REF=${{ env.CKAN_REF }}
             ENV=base
-            ${{ inputs.ckan-major-version == '2.11' && 'PYTHON_VERSION=${{ env.PY_VERSION_VALUE }}' || '' }}
+            ${{ env.PY_VERSION_VALUE && 'PYTHON_VERSION=${{ env.PY_VERSION_VALUE }}' || '' }}
           tags: ${{ env.BASE_TAGS }}
 
       - name: Build ${{ inputs.ckan-major-version }} dev

--- a/.github/workflows/reusable-docker-publish.yml
+++ b/.github/workflows/reusable-docker-publish.yml
@@ -117,6 +117,7 @@ jobs:
           build-args: |
             CKAN_REF=${{ env.CKAN_REF }}
             ENV=base
+            ${{ inputs.ckan-major-version == '2.11' && 'PYTHON_VERSION=${{ env.PY_VERSION_VALUE }}' || '' }}
           tags: ${{ env.BASE_TAGS }}
 
       - name: Build ${{ inputs.ckan-major-version }} dev
@@ -128,4 +129,5 @@ jobs:
           build-args: |
             CKAN_REF=${{ env.CKAN_REF }}
             ENV=dev
+            ${{ inputs.ckan-major-version == '2.11' && 'PYTHON_VERSION=${{ env.PY_VERSION_VALUE }}' || '' }}
           tags: ${{ env.DEV_TAGS }}


### PR DESCRIPTION
Fixes: https://github.com/ckan/ckan-docker-base/issues/119

The Dockerfile for CKAN **2.11** now includes an  `ARG PYTHON_VERSION` line so any script or process using this file will need to pass a build-arg to it

`reusable-docker-publish.yml` has been updated to pass this parameter to the CKAN 2.11 Dockerfile