### PR TITLE
Quote pip command that includes '>'

### DIFF
--- a/ckan-2.10/Dockerfile.py3.10
+++ b/ckan-2.10/Dockerfile.py3.10
@@ -74,7 +74,7 @@ COPY setup/supervisord.py3.conf /etc/supervisord.conf
 
 # Install uwsgi, the CKAN application, the dependency packages for CKAN plus some confiquration
 RUN pip3 install -U pip && \
-    pip3 install -U setuptools>=70.0.0 && \
+    pip3 install -U "setuptools>=70.0.0" && \
     pip3 install uwsgi && \
     cd ${SRC_DIR} && \
     pip3 install -e git+${GIT_URL}@${CKAN_REF}#egg=ckan && \

--- a/ckan-2.11/Dockerfile
+++ b/ckan-2.11/Dockerfile
@@ -68,7 +68,7 @@ RUN mkdir -p ${SRC_DIR}
 
 # Install uwsgi, the CKAN application, the dependency packages for CKAN plus some confiquration
 RUN pip3 install -U pip && \
-    pip3 install -U setuptools>=70.0.0 && \
+    pip3 install -U "setuptools>=70.0.0" && \
     pip3 install uwsgi && \
     cd ${SRC_DIR} && \
     pip3 install -e git+${GIT_URL}@${CKAN_REF}#egg=ckan && \

--- a/ckan-2.9/Dockerfile.py3.9
+++ b/ckan-2.9/Dockerfile.py3.9
@@ -75,7 +75,7 @@ COPY setup/supervisord.py3.conf /etc/supervisord.conf
 
 RUN pip3 install "webassets==0.12.1" && \
     pip3 install -U pip && \
-    pip3 install -U setuptools>=70.0.0 && \
+    pip3 install -U "setuptools>=70.0.0" && \
     pip3 install uwsgi && \
     cd ${SRC_DIR} && \
     pip3 install -e git+${GIT_URL}@${CKAN_REF}#egg=ckan && \


### PR DESCRIPTION
Otherwise, the output of the command is redirected into a file called '=70.0.0' and the pinned version is not passed to pip. (In this case that's okay, as the version pip installs by default is higher than the specified version.)